### PR TITLE
Remove flask-negotiate requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,6 @@ dependencies = ["Werkzeug"]
 
 [project.optional-dependencies]
 dev = [
-    "Flask-Negotiate==0.1.0",
     "Flask==2.2.3",
     "Sphinx-Substitution-Extensions==2022.2.16",
     "black==23.1.0",

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -20,7 +20,6 @@ import requests_mock
 import responses
 import werkzeug
 from flask import Flask, Response, jsonify, make_response, request
-from flask_negotiate import consumes
 from requests_mock_flask import add_flask_app_to_mock
 
 if TYPE_CHECKING:
@@ -727,8 +726,8 @@ def test_request_needs_content_type(mock_ctx: _MockCtxType) -> None:
     app = Flask(__name__)
 
     @app.route("/")
-    @consumes("application/json")  # type: ignore[misc]
     def _() -> str:
+        assert request.mimetype == "application/json"
         return "Hello, World!"
 
     test_client = app.test_client()
@@ -768,8 +767,8 @@ def test_request_needs_data(mock_ctx: _MockCtxType) -> None:
     app = Flask(__name__)
 
     @app.route("/")
-    @consumes("application/json")  # type: ignore[misc]
     def _() -> str:
+        assert request.mimetype == "application/json"
         request_json = request.get_json()
         assert isinstance(request_json, dict)
         return str(request_json["hello"])


### PR DESCRIPTION
This is no longer supported, and it required us to add type ignores.