### PR TITLE
Add view and edit buttons to Sphinx docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,6 +53,7 @@ html_show_sphinx = False
 html_show_sourcelink = False
 html_theme_options = {
     "sidebar_hide_name": False,
+    "top_of_page_buttons": ["view", "edit"],
 }
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
Add top_of_page_buttons configuration to Furo theme to enable view and edit buttons on documentation pages.