### PR TITLE
Configure Furo top-of-page buttons with repository details

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,7 +53,9 @@ html_show_sphinx = False
 html_show_sourcelink = False
 html_theme_options = {
     "sidebar_hide_name": False,
-    "top_of_page_buttons": ["view", "edit"],
+    "source_repository": "https://github.com/adamtheturtle/requests-mock-flask/",
+    "source_branch": "main",
+    "source_directory": "docs/source/",
 }
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
Configures Furo theme with source_repository, source_branch, and source_directory to enable view and edit buttons on documentation pages.

See https://furo.readthedocs.io/customisation/top-of-page-buttons.html#with-popular-vcs-hosts