### PR TITLE
Bump beartype to 0.22.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.9.24",
-    "beartype==0.22.8",
+    "beartype==0.22.9",
     "check-manifest==0.51",
     "deptry==0.24.0",
     "doc8==2.0.0",


### PR DESCRIPTION
Bump beartype dependency to 0.22.9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update dev dependency `beartype` from `0.22.8` to `0.22.9` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39a6c3fe6e905111a14029e40ab7cb197d091599. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->