### PR TITLE
Cast in a better way

### DIFF
--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -5,7 +5,7 @@ Package for ``requests_mock_flask``.
 import re
 from http.cookies import SimpleCookie
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 import httpretty  # pyright: ignore[reportMissingTypeStubs]
@@ -209,12 +209,8 @@ def _httpretty_callback(
     if "Content-Length" in request.headers:
         environ_overrides["CONTENT_LENGTH"] = request.headers["Content-Length"]
 
-    # We cast the path to a string because httpretty types it as
-    # str | bytes, but in practice it's always a string when handling
-    # HTTP requests.
-    path = cast("str", request.path)  # type: ignore[redundant-cast]  # pyright: ignore[reportUnnecessaryCast]
     environ_builder = werkzeug.test.EnvironBuilder(
-        path=path,
+        path=str(object=request.path),
         method=request.method,
         headers=request.headers.items(),
         data=request.body,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace redundant typing cast with explicit str() for `request.path` in HTTPretty callback and remove unused `cast` import.
> 
> - **`src/requests_mock_flask/__init__.py`**
>   - **HTTPretty callback**: Use `str(object=request.path)` for `werkzeug.test.EnvironBuilder(path=...)` instead of a `typing.cast`.
>   - **Imports**: Remove unused `cast` from `typing`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17382e030be9151e8a9c36aafc6cbf458416357d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->