### PR TITLE
Switch from pre-commit to prek

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
 
       - name: Lint
         run: |
-          uv run --extra=dev pre-commit run --all-files --hook-stage pre-commit --verbose
-          uv run --extra=dev pre-commit run --all-files --hook-stage pre-push --verbose
-          uv run --extra=dev pre-commit run --all-files --hook-stage manual --verbose
+          uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
+          uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose
+          uv run --extra=dev prek run --all-files --hook-stage manual --verbose
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ ci:
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-default_install_hook_types: [pre-commit, pre-push, commit-msg]
+default_install_hook_types: [pre-commit, pre-push]
 
 repos:
   - repo: meta

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -31,7 +31,7 @@ Install ``pre-commit`` hooks:
 
 .. code-block:: console
 
-   $ pre-commit install
+   $ prek install
 
 Linting
 -------
@@ -40,9 +40,9 @@ Run lint tools either by committing, or with:
 
 .. code-block:: console
 
-   $ pre-commit run --all-files --hook-stage pre-commit --verbose
-   $ pre-commit run --all-files --hook-stage pre-push --verbose
-   $ pre-commit run --all-files --hook-stage manual --verbose
+   $ prek run --all-files --hook-stage pre-commit --verbose
+   $ prek run --all-files --hook-stage pre-push --verbose
+   $ prek run --all-files --hook-stage manual --verbose
 
 .. _Homebrew: https://brew.sh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "mypy-strict-kwargs==2025.4.3",
-    "pre-commit==4.5.1",
+    "prek==0.2.25",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
     "pyproject-fmt==2.11.1",


### PR DESCRIPTION
Replace pre-commit with prek for running hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves hook execution from `pre-commit` to `prek` across the project.
> 
> - CI: Lint step now runs `prek run` for `pre-commit`, `pre-push`, and `manual` stages
> - Docs: Contributor commands updated from `pre-commit` to `prek`
> - Dev deps: Replace `pre-commit` with `prek` in `pyproject.toml`
> - Config: `.pre-commit-config.yaml` sets `default_install_hook_types` to `[pre-commit, pre-push]` (removes `commit-msg`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9cace4cf29d7a1913d3f50436bf3c028a474bd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->