### PR TITLE
Make prettier more compatible with yamlfix

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
       "files": ["*.yaml", "*.yml"],
       "options": {
         "singleQuote": true,
-        "printWidth": 100"
+        "printWidth": 100
       }
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - Updates `.prettierrc` to set `printWidth: 100` for `*.yaml`/`*.yml` files under the YAML override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61b5e9cad12d8eb755ded0450a8b14656400640f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->