### PR TITLE
Fix block scalar newline interpretation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n"
+          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
+            \ }}\n"
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
The previous fix used a YAML block scalar (`|-`) which doesn't interpret `\n` as newlines, causing literal `\n` to appear in CHANGELOG.rst. This fix uses a double-quoted string on a single line which correctly interprets escape sequences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the release workflow writes proper newlines to `CHANGELOG.rst` during the find/replace step.
> 
> - In `.github/workflows/release.yml`, replaces YAML block scalar (`|-`) with a double-quoted string for the `replace` value in the `gha-find-replace` step so `\n` escape sequences are interpreted as actual newlines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 625960bc4bf8e15d34b029c84b543ebf3f368571. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->