### PR TITLE
Use literal block scalar for changelog replace string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,12 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
-            \ }}\n"
+          replace: |
+            Next
+            ----
+
+            ${{ steps.calver.outputs.release }}
+            ${{ steps.changelog_underline.outputs.underline }}
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
Use literal block scalar (`|`) with actual newlines instead of escape sequences in the release workflow. This fixes zizmor warnings while being compatible with yamlfix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **ci: Update release workflow changelog step**
> 
> - Replaces escaped-newline string with a YAML literal block (`|`) for the `replace` value in `release.yml`, writing actual newlines when updating `CHANGELOG.rst`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01a337d1dfcdbe6ab78a6bfc1d6bde9467b3501e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->