### PR TITLE
Use structural pattern matching for mock backend dispatch

### DIFF
--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -32,10 +32,10 @@ _MockObjType = (
 class _MockCallbacks(NamedTuple):
     """Callbacks for each supported mock backend."""
 
-    responses: Callable[..., object]
-    requests_mock: Callable[..., object]
-    respx: Callable[..., object]
-    httpretty: Callable[..., object]
+    responses: Callable[..., Any]
+    requests_mock: Callable[..., Any]
+    respx: Callable[..., Any]
+    httpretty: Callable[..., Any]
 
 
 def _register_mock(

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -1,10 +1,11 @@
 """Package for ``requests_mock_flask``."""
 
+import dataclasses
 import re
 from collections.abc import Callable
 from http.cookies import SimpleCookie
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 import httpretty  # pyright: ignore[reportMissingTypeStubs]
@@ -29,7 +30,8 @@ _MockObjType = (
 )
 
 
-class _MockCallbacks(NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class _MockCallbacks:
     """Callbacks for each supported mock back end."""
 
     responses: Callable[..., Any]

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -30,7 +30,7 @@ _MockObjType = (
 
 
 class _MockCallbacks(NamedTuple):
-    """Callbacks for each supported mock backend."""
+    """Callbacks for each supported mock back end."""
 
     responses: Callable[..., Any]
     requests_mock: Callable[..., Any]
@@ -44,9 +44,9 @@ def _register_mock(
     url: re.Pattern[str],
     callbacks: _MockCallbacks,
 ) -> None:
-    """Register a single method/URL pair with the given mock backend.
+    """Register a single method/URL pair with the given mock back end.
 
-    To support a new mock backend, add a case branch.
+    To support a new mock back end, add a case branch.
     """
     match mock_obj:
         case responses.RequestsMock():

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -1,9 +1,10 @@
 """Package for ``requests_mock_flask``."""
 
 import re
+from collections.abc import Callable
 from http.cookies import SimpleCookie
 from types import ModuleType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import urljoin
 
 import httpretty  # pyright: ignore[reportMissingTypeStubs]
@@ -26,6 +27,67 @@ _MockObjType = (
     | respx.Router
     | ModuleType
 )
+
+
+class _MockCallbacks(NamedTuple):
+    """Callbacks for each supported mock backend."""
+
+    responses: Callable[..., object]
+    requests_mock: Callable[..., object]
+    respx: Callable[..., object]
+    httpretty: Callable[..., object]
+
+
+def _register_mock(
+    mock_obj: _MockObjType,
+    method: str,
+    url: re.Pattern[str],
+    callbacks: _MockCallbacks,
+) -> None:
+    """Register a single method/URL pair with the given mock backend.
+
+    To support a new mock backend, add a case branch.
+    """
+    match mock_obj:
+        case responses.RequestsMock():
+            mock_obj.add_callback(
+                method=method,
+                url=url,
+                callback=callbacks.responses,
+                content_type=None,
+            )
+        case ModuleType() if mock_obj.__name__ == "responses":
+            mock_obj.add_callback(
+                method=method,
+                url=url,
+                callback=callbacks.responses,
+                content_type=None,
+            )
+        case requests_mock.Mocker() | requests_mock.Adapter():
+            mock_obj.register_uri(
+                method=method,
+                url=url,
+                text=callbacks.requests_mock,
+            )
+        case respx.MockRouter() | respx.Router():
+            mock_obj.route(
+                method=method,
+                url__regex=url.pattern,
+            ).mock(side_effect=callbacks.respx)
+        case ModuleType() if mock_obj.__name__ == "httpretty":
+            httpretty.register_uri(  # type: ignore[no-untyped-call]  # pyright: ignore[reportUnknownMemberType]
+                method=method,
+                uri=url,
+                body=callbacks.httpretty,  # pyright: ignore[reportArgumentType]
+                forcing_headers={"Content-Type": None},
+            )
+        case _:
+            msg = (
+                "Expected a HTTPretty, ``requests_mock``, "
+                "``respx``, or ``responses`` object, got "
+                f"module '{mock_obj.__name__}'."
+            )
+            raise TypeError(msg)
 
 
 def add_flask_app_to_mock(
@@ -76,6 +138,13 @@ def add_flask_app_to_mock(
             flask_app=flask_app,
         )
 
+    callbacks = _MockCallbacks(
+        responses=responses_callback,
+        requests_mock=requests_mock_callback,
+        respx=respx_side_effect,
+        httpretty=httpretty_callback,
+    )
+
     for rule in flask_app.url_map.iter_rules():
         # We replace everything inside angle brackets with a regex pattern.
         # For path variables (<path:...>), we use .+ to match any characters
@@ -97,43 +166,12 @@ def add_flask_app_to_mock(
         methods = rule.methods or set()
         for method in methods:
             for url in urls:
-                if isinstance(mock_obj, responses.RequestsMock) or (
-                    isinstance(mock_obj, ModuleType)
-                    and mock_obj.__name__ == "responses"
-                ):
-                    mock_obj.add_callback(
-                        method=method,
-                        url=url,
-                        callback=responses_callback,
-                        content_type=None,
-                    )
-                elif isinstance(
-                    mock_obj, (requests_mock.Mocker | requests_mock.Adapter)
-                ):
-                    mock_obj.register_uri(
-                        method=method,
-                        url=url,
-                        text=requests_mock_callback,
-                    )
-                elif isinstance(mock_obj, (respx.MockRouter, respx.Router)):
-                    mock_obj.route(
-                        method=method,
-                        url__regex=url.pattern,
-                    ).mock(side_effect=respx_side_effect)
-                elif mock_obj.__name__ == "httpretty":
-                    httpretty.register_uri(  # type: ignore[no-untyped-call]  # pyright: ignore[reportUnknownMemberType]
-                        method=method,
-                        uri=url,
-                        body=httpretty_callback,  # pyright: ignore[reportArgumentType]
-                        forcing_headers={"Content-Type": None},
-                    )
-                else:
-                    msg = (
-                        "Expected a HTTPretty, ``requests_mock``, "
-                        "``respx``, or ``responses`` object, got "
-                        f"module '{mock_obj.__name__}'."
-                    )
-                    raise TypeError(msg)
+                _register_mock(
+                    mock_obj=mock_obj,
+                    method=method,
+                    url=url,
+                    callbacks=callbacks,
+                )
 
 
 def _responses_callback(

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -51,14 +51,10 @@ def _register_mock(
     To support a new mock back end, add a case branch.
     """
     match mock_obj:
-        case responses.RequestsMock():
-            mock_obj.add_callback(
-                method=method,
-                url=url,
-                callback=callbacks.responses,
-                content_type=None,
-            )
-        case ModuleType() if mock_obj.__name__ == "responses":
+        case responses.RequestsMock() | ModuleType() if (
+            not isinstance(mock_obj, ModuleType)
+            or mock_obj.__name__ == "responses"
+        ):
             mock_obj.add_callback(
                 method=method,
                 url=url,
@@ -84,10 +80,15 @@ def _register_mock(
                 forcing_headers={"Content-Type": None},
             )
         case _:
+            name = getattr(
+                mock_obj,
+                "__name__",
+                type(mock_obj).__name__,
+            )
             msg = (
                 "Expected a HTTPretty, ``requests_mock``, "
                 "``respx``, or ``responses`` object, got "
-                f"module '{mock_obj.__name__}'."
+                f"module '{name}'."
             )
             raise TypeError(msg)
 


### PR DESCRIPTION
## Summary
- Replaces the `if isinstance`/`elif` ladder in `add_flask_app_to_mock` with a `match`/`case` statement for dispatching mock registration to each backend (responses, requests_mock, respx, httpretty).
- Extracts the dispatch logic into a dedicated `_register_mock` helper with a `_MockCallbacks` NamedTuple to bundle callbacks, keeping complexity within linter limits.
- Behavior is unchanged; all existing tests pass.

Closes #1696

## Test plan
- [x] All 116 existing tests pass
- [x] Pre-commit hooks (ruff, mypy, pyright, vulture, interrogate) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors mock-backend dispatch into a new helper using structural pattern matching; behavior should be unchanged but regressions could affect test-time request interception across supported mocking libraries.
> 
> **Overview**
> Refactors `add_flask_app_to_mock` to remove the `isinstance`/`elif` ladder and delegate backend-specific route registration to a new `_register_mock` helper using `match`/`case`.
> 
> Introduces a frozen `_MockCallbacks` dataclass to bundle the per-backend callbacks passed into `_register_mock`, and slightly improves the TypeError reporting for unsupported mock objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7d885671c6c8254393e68db353ebd89d04cfb59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->