### PR TITLE
chore: use deptry optional_dependencies_dev_groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,7 +271,7 @@ ignore = [
 ]
 
 [tool.deptry]
-pep621_dev_dependency_groups = [
+optional_dependencies_dev_groups = [
     "dev",
     "release",
 ]


### PR DESCRIPTION
Renames `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` for deptry 0.25+.

This removes deprecation warnings; the old key may be removed in a future deptry release.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a config-only rename in `pyproject.toml` to match newer `deptry` versions; impact is limited to tooling behavior if the key is misspelled or an older deptry is used.
> 
> **Overview**
> Updates `pyproject.toml` deptry configuration by renaming the dev dependency-groups setting from `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` (for deptry 0.25+), eliminating deprecation warnings and keeping the configured `dev`/`release` groups unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b0caf93aa1e1f713f938ad1f1795bc03df3d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->