### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,18 +2,8 @@
 
 from doctest import ELLIPSIS
 
-import pytest
-from beartype import beartype
 from sybil import Sybil
 from sybil.parsers.rest import DocTestParser, PythonCodeBlockParser
-
-
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        if isinstance(item, pytest.Function):
-            item.obj = beartype(obj=item.obj)
-
 
 sybil = Sybil(
     parsers=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests==2026.4.19.1",
+    "pytest-beartype-tests",
     "pytest-cov==7.1.0",
     "requests==2.33.1",
     "ruff==0.15.11",
@@ -112,6 +112,9 @@ bdist_wheel.universal = true
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
+
+[tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests==2026.4.19.1",
     "pytest-cov==7.1.0",
     "requests==2.33.1",
     "ruff==0.15.11",
@@ -88,6 +89,9 @@ optional-dependencies.dev = [
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://adamtheturtle.github.io/requests-mock-flask/"
 urls.Source = "https://github.com/adamtheturtle/requests-mock-flask"
+
+[dependency-groups]
+dev = []
 
 [tool.setuptools]
 zip-safe = false
@@ -341,7 +345,6 @@ ignore_path = [
 ignore_names = [
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` / `@beartype` wiring from conftest where it duplicated the plugin.

The plugin registers via `pytest11` and applies `@beartype` to collected test functions, matching the previous local hook behavior (see the [upstream README](https://github.com/adamtheturtle/pytest-beartype-tests)).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the test toolchain by swapping a local pytest hook for an external plugin, with no production/runtime code impact.
> 
> **Overview**
> Test-time `@beartype` enforcement is delegated to the external `pytest-beartype-tests` plugin by removing the custom `pytest_collection_modifyitems` hook from `conftest.py`.
> 
> `pyproject.toml` adds `pytest-beartype-tests` to dev deps (sourced via `uv` from a pinned Git revision), introduces an empty `[dependency-groups]` `dev`, and drops the now-unused Vulture ignore for `pytest_collection_modifyitems`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a8be2c0ca73434848c3f6bdf8a04ff06c27297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->