### PR TITLE
Bump mypy to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ optional-dependencies.dev = [
     "furo==2025.12.19",
     "httpx==0.28.1",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.13",
     "pydocstringformatter==0.7.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dev-only dependency bump; main risk is CI/type-check failures or new diagnostics from mypy 2.0.0.
> 
> **Overview**
> Updates the dev dependency `mypy[faster-cache]` from `1.20.2` to `2.0.0` in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f4ad60fc57da16087c538427f3518ad77c4205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->