### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,18 +156,18 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-workers 0
         language: python
         types_or: [python, toml]
         pass_filenames: false
         additional_dependencies:
           - *uv_version
 
-      # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers 0"
         language: python
         types_or: [markdown, rst]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy --num-workers 0
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -167,7 +167,7 @@ repos:
         name: mypy-docs
         stages: [pre-push]
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
-          --num-workers 0"
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
 


### PR DESCRIPTION
## Summary
- enable mypy parallel workers in pre-commit by adding `--num-workers 0` to the mypy hook
- update `mypy-docs` so the workers flag is passed inside the quoted doccmd command string

## Test plan
- [x] pre-commit hooks pass during commit

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pre-commit hook command lines to enable mypy parallelism; no runtime/application logic changes.
> 
> **Overview**
> Speeds up pre-push type checking by running `mypy` with `--num-workers=4` in the `mypy` pre-commit hook.
> 
> Updates the `mypy-docs` hook so the same flag is included inside the `doccmd` `--command` string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e9aa04a923652b3dc376c1cef8603939e5870f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->