### PR TITLE
Ban dynamic builtins and typing.cast in lint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ lint.per-file-ignores."tests/test_*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.mccabe.max-complexity = 12
 lint.pydocstyle.convention = "google"
 
@@ -188,6 +189,17 @@ MASTER.load-plugins = [
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
+DEPRECATED_BUILTINS.bad-functions = [
+    # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
+    # make this removable:
+    # https://github.com/astral-sh/ruff/issues/10079
+    # https://github.com/astral-sh/ruff/issues/970
+    "filter",
+    "getattr",
+    "hasattr",
+    "map",
+    "setattr",
+]
 DESIGN.max-complexity = 12
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -79,12 +79,10 @@ def _register_mock(
                 body=callbacks.httpretty,  # pyright: ignore[reportArgumentType]
                 forcing_headers={"Content-Type": None},
             )
+        case ModuleType() as module:
+            name = module.__name__
         case _:
-            name = getattr(
-                mock_obj,
-                "__name__",
-                type(mock_obj).__name__,
-            )
+            name = type(mock_obj).__name__
             msg = (
                 "Expected a HTTPretty, ``requests_mock``, "
                 "``respx``, or ``responses`` object, got "

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -79,10 +79,12 @@ def _register_mock(
                 body=callbacks.httpretty,  # pyright: ignore[reportArgumentType]
                 forcing_headers={"Content-Type": None},
             )
-        case ModuleType() as module:
-            name = module.__name__
         case _:
-            name = type(mock_obj).__name__
+            name = getattr(  # pylint: disable=bad-builtin
+                mock_obj,
+                "__name__",
+                type(mock_obj).__name__,
+            )
             msg = (
                 "Expected a HTTPretty, ``requests_mock``, "
                 "``respx``, or ``responses`` object, got "


### PR DESCRIPTION
## Summary
- Add literalizer DEPRECATED_BUILTINS.bad-functions pylint config (filter, getattr, hasattr, map, setattr).
- Ban typing.cast imports via ruff flake8-tidy-imports where the project uses ruff.
- Fix or pylint-disable existing violations uncovered by the new rules.

## Test plan
- [ ] CI lint passes (pylint, ruff, pre-commit).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to static lint configuration plus a `pylint` suppression comment, with no functional runtime behavior changes.
> 
> **Overview**
> **Lint rules are tightened** by banning `typing.cast` via Ruff’s `flake8-tidy-imports` config and by adding Pylint `DEPRECATED_BUILTINS.bad-functions` entries for dynamic builtins (`filter`, `getattr`, `hasattr`, `map`, `setattr`).
> 
> **One existing use is annotated** with `# pylint: disable=bad-builtin` on a `getattr` call in `_register_mock` to comply with the new Pylint rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb9692aa6370e049ab59c027997e5f18a5df0d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->