### PR TITLE
Replace getattr with isinstance in _register_mock

### DIFF
--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -80,11 +80,10 @@ def _register_mock(
                 forcing_headers={"Content-Type": None},
             )
         case _:
-            name = getattr(  # pylint: disable=bad-builtin
-                mock_obj,
-                "__name__",
-                type(mock_obj).__name__,
-            )
+            if isinstance(mock_obj, ModuleType):
+                name = mock_obj.__name__
+            else:
+                name = type(mock_obj).__name__
             msg = (
                 "Expected a HTTPretty, ``requests_mock``, "
                 "``respx``, or ``responses`` object, got "

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -11,7 +11,7 @@ from contextlib import AbstractContextManager
 from functools import partial
 from http import HTTPStatus
 from types import ModuleType
-from typing import Final
+from typing import Any, Final
 
 import httpretty  # pyright: ignore[reportMissingTypeStubs]
 import httpx
@@ -1309,6 +1309,29 @@ def test_unknown_mock_module() -> None:
     with pytest.raises(expected_exception=TypeError, match=expected_error):
         add_flask_app_to_mock(
             mock_obj=json,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+
+
+def test_unknown_mock_object() -> None:
+    """When an unknown mock object is passed in, an error is raised."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/")
+    def _() -> str:
+        """Return a simple message."""
+        return ""  # pragma: no cover
+
+    unknown_mock_obj: Any = object()
+    expected_error = (
+        "Expected a HTTPretty, ``requests_mock``, "
+        "``respx``, or ``responses`` object, "
+        "got module 'object'."
+    )
+    with pytest.raises(expected_exception=TypeError, match=expected_error):
+        add_flask_app_to_mock(
+            mock_obj=unknown_mock_obj,
             flask_app=app,
             base_url="http://www.example.com",
         )


### PR DESCRIPTION
## Summary
- Remove the `getattr` call (and its `bad-builtin` pylint disable) from `_register_mock`'s default match case.
- Use an explicit `isinstance(mock_obj, ModuleType)` check to derive the unsupported object name for the `TypeError` message.

Follow-up to #1751, which banned dynamic builtins in pylint config but left a suppression on this call site.

## Test plan
- [x] `pytest tests/test_requests_mock_flask.py::test_unknown_mock_module`
- [x] Pre-commit hooks pass (pylint, ruff, mypy, pyright, etc.)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how the unsupported `mock_obj` name is derived for a `TypeError` message and adds a targeted regression test; no request-routing behavior is affected.
> 
> **Overview**
> Simplifies `_register_mock`'s unsupported-backend error path by replacing `getattr` with an explicit `isinstance(mock_obj, ModuleType)` check to compute the name used in the raised `TypeError` (removing the related pylint suppression).
> 
> Adds a new test (`test_unknown_mock_object`) to ensure non-module, unsupported mock objects also raise with the expected error message, alongside the existing unknown-module coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ca1d0f734cb369930a2c4512fffc3f3d0c00a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->