### PR TITLE
[codex] Add towncrier to release extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ optional-dependencies.dev = [
     "yamlfix==1.19.1",
     "zizmor==1.25.2",
 ]
-optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
+optional-dependencies.release = [ "check-wheel-contents==0.6.3", "towncrier==25.8.0" ]
 urls.Documentation = "https://adamtheturtle.github.io/requests-mock-flask/"
 urls.Source = "https://github.com/adamtheturtle/requests-mock-flask"
 


### PR DESCRIPTION
## Summary

Add `towncrier==25.8.0` to the `release` extra so the release workflow can run:

```bash
uv run --extra=release towncrier build ...
```

The previous towncrier migration added the tool for development/docs builds, but release jobs install only the `release` extra before invoking towncrier.

## Validation

- `uv lock`
- `uv run --no-dev --extra=release towncrier --version`
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts packaging metadata to add a pinned dependency to the `release` extra, with no runtime code changes.
> 
> **Overview**
> Adds `towncrier==25.8.0` to the `release` optional dependency set in `pyproject.toml`, ensuring release installs that use `--extra=release` have `towncrier` available to build changelogs/release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7de07c130debefaa666fc617521373b598e87a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->