### PR TITLE
fix: Preserve binary response bodies with requests-mock

### DIFF
--- a/newsfragments/1829.change.rst
+++ b/newsfragments/1829.change.rst
@@ -1,0 +1,1 @@
+Preserve binary response bodies when using the ``requests_mock`` back end.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -65,7 +65,7 @@ def _register_mock(
             mock_obj.register_uri(
                 method=method,
                 url=url,
-                text=callbacks.requests_mock,
+                content=callbacks.requests_mock,
             )
         case respx.MockRouter() | respx.Router():
             mock_obj.route(
@@ -119,7 +119,7 @@ def add_flask_app_to_mock(
     def requests_mock_callback(
         request: "requests_mock.Request",
         context: "requests_mock.Context",
-    ) -> str:
+    ) -> bytes:
         """Callback for requests_mock."""
         return _requests_mock_callback(
             request=request,
@@ -290,7 +290,7 @@ def _requests_mock_callback(
     request: "requests_mock.Request",
     context: "requests_mock.Context",
     flask_app: "flask.Flask",
-) -> str:
+) -> bytes:
     """Given a request to the Flask app, send an equivalent request to an
     in
     memory fake of the Flask app and return some key details of the
@@ -336,4 +336,4 @@ def _requests_mock_callback(
 
     context.headers = dict(response.headers)
     context.status_code = response.status_code
-    return str(object=response.data.decode())
+    return bytes(response.data)

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -134,6 +134,50 @@ def test_simple_route(mock_ctx: _MockCtxType) -> None:
 
 
 @_MOCK_CTX_MARKER
+def test_binary_response(mock_ctx: _MockCtxType) -> None:
+    """A binary response body is preserved byte-for-byte."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    expected_data = b"\xff\x00\xfe"
+
+    @app.route(rule="/")
+    def _() -> Response:
+        """Return a binary response body."""
+        return Response(
+            response=expected_data,
+            content_type="application/octet-stream",
+        )
+
+    test_client = app.test_client()
+    response = test_client.get("/")
+
+    expected_status_code = HTTPStatus.OK
+    expected_content_type = "application/octet-stream"
+
+    assert response.status_code == expected_status_code
+    assert response.headers["Content-Type"] == expected_content_type
+    assert response.data == expected_data
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com",
+        )
+
+    assert mock_response.status_code == expected_status_code
+    assert mock_response.headers["Content-Type"] == expected_content_type
+    assert mock_response.content == expected_data
+
+
+@_MOCK_CTX_MARKER
 def test_headers(mock_ctx: _MockCtxType) -> None:
     """Request headers are sent."""
     app = Flask(import_name=__name__, static_folder=None)


### PR DESCRIPTION
Closes #1829.

The `requests_mock` callback previously decoded every Flask response body as UTF-8 and returned it through requests-mock's `text=` callback, so valid binary responses (e.g. `application/octet-stream`) raised `UnicodeDecodeError`. This switches registration to requests-mock's byte-lossless `content=` callback and returns the raw response bytes, so binary bodies are preserved byte-for-byte and match the behaviour of the responses, HTTPretty, and RESPX back ends. Adds a `test_binary_response` test parametrized across all four back ends and a news fragment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to the requests_mock integration path; UTF-8 text responses remain valid as bytes and behavior aligns with other backends.
> 
> **Overview**
> Fixes **`requests_mock`** so Flask response bodies are forwarded as raw bytes instead of being UTF-8 decoded and registered via **`text=`**, which broke binary payloads (e.g. **`application/octet-stream`**) with **`UnicodeDecodeError`**.
> 
> Registration now uses **`content=`** and **`_requests_mock_callback`** returns **`bytes(response.data)`**, matching the byte-preserving behavior of the **responses**, **HTTPretty**, and **respx** paths. Adds **`test_binary_response`** (parametrized across all four backends) and a news fragment for #1829.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a80008a6e98338029750cbe2e156019ccf71d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->