### PR TITLE
fix: Escape literal URL components when registering Flask routes

### DIFF
--- a/newsfragments/1828.change.rst
+++ b/newsfragments/1828.change.rst
@@ -1,1 +1,1 @@
-Escape regex metacharacters in literal URL components.
+Escape regex meta-characters in literal URL components.

--- a/newsfragments/1828.change.rst
+++ b/newsfragments/1828.change.rst
@@ -1,0 +1,1 @@
+Escape regex metacharacters in literal URL components.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -181,7 +181,8 @@ def add_flask_app_to_mock(
         # should still be forwarded to the Flask app so that it can produce the
         # appropriate response (e.g. a 404). Literal parts are kept literal.
         path_to_match = _rule_to_path_regex(rule=rule)
-        patterns = [urljoin(base=base_url, url=path_to_match)]
+        escaped_base_url = re.escape(pattern=base_url)
+        patterns = [urljoin(base=escaped_base_url, url=path_to_match)]
         has_slashless_redirect = (
             rule.strict_slashes
             and path_to_match.endswith("/")
@@ -191,7 +192,7 @@ def add_flask_app_to_mock(
             patterns.append(patterns[0].rstrip("/"))
         elif has_slashless_redirect:
             patterns.append(
-                urljoin(base=base_url, url=path_to_match.rstrip("/"))
+                urljoin(base=escaped_base_url, url=path_to_match.rstrip("/"))
             )
         urls = tuple(
             re.compile(pattern=pattern + r"(\?.*)?$") for pattern in patterns

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1731,6 +1731,44 @@ def test_string_variable_rejects_extra_segments(
             )
 
 
+@_MOCK_CTX_MARKER_NO_HTTPRETTY
+def test_literal_url_components_are_escaped(
+    mock_ctx: _MockCtxType,
+) -> None:
+    """Regex metacharacters in literal URL components stay literal."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/literal.json")
+    def _() -> str:
+        """Return a simple message."""
+        return "matched"
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://api.example.com",
+        )
+        matched_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://api.example.com/literal.json",
+        )
+        assert matched_response.status_code == HTTPStatus.OK
+        assert matched_response.text == "matched"
+
+        expected_exceptions: tuple[type[Exception], ...] = (
+            AllMockedAssertionError,
+            requests.exceptions.ConnectionError,
+            NoMockAddress,
+        )
+        with pytest.raises(expected_exception=expected_exceptions):
+            _do_get(
+                mock_obj=mock_obj_to_add,
+                url="http://apiXexampleYcom/literalXjson",
+            )
+
+
 def test_unknown_mock_module() -> None:
     """When an unknown mock module is passed in, an error is raised."""
     app = Flask(import_name=__name__, static_folder=None)

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1735,7 +1735,7 @@ def test_string_variable_rejects_extra_segments(
 def test_literal_url_components_are_escaped(
     mock_ctx: _MockCtxType,
 ) -> None:
-    """Regex metacharacters in literal URL components stay literal."""
+    """Regex meta-characters in literal URL components stay literal."""
     app = Flask(import_name=__name__, static_folder=None)
 
     @app.route(rule="/literal.json")


### PR DESCRIPTION
Closes #1828.

`add_flask_app_to_mock` previously interpolated the `base_url` and the static parts of each Flask rule directly into a matching regex, so metacharacters such as `.` acted as wildcards and could intercept unrelated hosts or paths. This escapes the literal URL components with `re.escape` while keeping the generated placeholders for Flask variables (`.+` for `<path:...>`, `[^/]+` otherwise) as regex patterns. This affects all four backends (responses, requests_mock, httpretty, respx), which share the construction. A new parametrized test encodes the issue reproduction: the literal `http://api.example.com/literal.json` matches, while `http://apiXexampleYcom/literalXjson` is left unmatched (asserted on responses, requests_mock, and respx; httpretty is excluded from unmatched-request assertions per the existing HTTPretty limitation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix to URL pattern construction in test mocking; behavior change only tightens matching to intended literals.
> 
> **Overview**
> Fixes overly broad mock URL matching when `base_url` or static path segments contain regex metacharacters (e.g. `.` in `api.example.com` or `/literal.json`).
> 
> **`add_flask_app_to_mock`** now runs `re.escape` on `base_url` before building the compiled patterns used by all mock backends; Flask variable placeholders from `_rule_to_path_regex` stay as intentional regex. A parametrized test asserts the real URL matches while a lookalike host/path with different characters does not (httpretty excluded from the negative assertion, same as other routing tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79673a8435563cd8dab5ca1542bb3475c9c45acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->