### PR TITLE
fix: Forward unsupported methods so Flask can return 405 responses

### DIFF
--- a/newsfragments/1834.change.rst
+++ b/newsfragments/1834.change.rst
@@ -1,0 +1,1 @@
+Requests using an unsupported method for a known route are now forwarded to Flask, which returns its usual ``405 Method Not Allowed`` response.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -20,6 +20,25 @@ if TYPE_CHECKING:
     import requests
 
 
+# Known HTTP methods to register for every route URL. We register all of
+# these (rather than only the methods a rule supports) so that requests using
+# an unsupported method for a known path are still forwarded to Flask, which
+# then returns its usual ``405 Method Not Allowed`` response (including the
+# ``Allow`` header and any custom error handler).
+_KNOWN_HTTP_METHODS = frozenset(
+    {
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "TRACE",
+    },
+)
+
+
 _MockObjType = (
     responses.RequestsMock
     | requests_mock.Mocker
@@ -165,7 +184,7 @@ def add_flask_app_to_mock(
         pattern = urljoin(base=base_url, url=path_to_match)
         urls = (re.compile(pattern=pattern), re.compile(pattern=pattern + "$"))
 
-        methods = rule.methods or set()
+        methods = (rule.methods or set()) | _KNOWN_HTTP_METHODS
         for method in methods:
             for url in urls:
                 _register_mock(

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -809,17 +809,15 @@ def test_405_no_such_method(mock_ctx: _MockCtxType) -> None:
             base_url="http://www.example.com",
         )
 
-        expected_exceptions: tuple[type[Exception], ...] = (
-            AllMockedAssertionError,
-            requests.exceptions.ConnectionError,
-            NoMockAddress,
-            ValueError,
+        mock_response = _do_post(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com/",
         )
-        with pytest.raises(expected_exception=expected_exceptions):
-            _do_post(
-                mock_obj=mock_obj_to_add,
-                url="http://www.example.com/",
-            )
+
+    assert mock_response.status_code == expected_status_code
+    assert mock_response.headers["Content-Type"] == expected_content_type
+    assert mock_response.headers["Allow"] == response.headers["Allow"]
+    assert "not allowed for the requested URL." in mock_response.text
 
 
 @_MOCK_CTX_MARKER


### PR DESCRIPTION
Closes #1834.

`add_flask_app_to_mock` previously registered each route URL only for the methods listed on its Flask rule, so a request using an unsupported method for a known path was rejected by the mock backend before reaching Flask. Callers could not observe Flask's normal `405 Method Not Allowed` response.

This registers every known route URL for the full set of standard HTTP methods, leaving Flask responsible for method routing and 405 responses (including the `Allow` header and any custom error handlers). Unknown paths remain unmatched as before.

`test_405_no_such_method` is updated to assert the POST is forwarded and returns Flask's actual 405 response on all four backends (responses, requests_mock, httpretty, respx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted test-helper routing change with broader mock registrations; behavior aligns with Flask and is covered by updated tests.
> 
> **Overview**
> **`add_flask_app_to_mock`** now registers each known route URL for the standard HTTP methods (GET, HEAD, OPTIONS, POST, PUT, DELETE, PATCH, TRACE), not only the methods on the Flask rule. Unsupported methods on a matched path reach Flask and return a real **405 Method Not Allowed** (including **`Allow`** and custom error handlers) instead of failing inside the mock layer.
> 
> **`test_405_no_such_method`** expects that POST behavior across all mock backends. A newsfragment documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 202fbb49205a27d8d5ef41c0e0585c423f1d8568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->