### PR TITLE
fix: Forward missing-trailing-slash requests for Flask redirects

### DIFF
--- a/newsfragments/1835.change.rst
+++ b/newsfragments/1835.change.rst
@@ -1,0 +1,1 @@
+Requests to the slashless form of a slash-terminated Flask route are now forwarded so that Flask can produce its trailing-slash redirect.

--- a/newsfragments/1835.change.rst
+++ b/newsfragments/1835.change.rst
@@ -1,1 +1,1 @@
-Requests to the slashless form of a slash-terminated Flask route are now forwarded so that Flask can produce its trailing-slash redirect.
+Requests to the form without a trailing slash of a slash-terminated Flask route are now forwarded so that Flask can produce its trailing-slash redirect.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -181,16 +181,14 @@ def add_flask_app_to_mock(
         # should still be forwarded to the Flask app so that it can produce the
         # appropriate response (e.g. a 404). Literal parts are kept literal.
         path_to_match = _rule_to_path_regex(rule=rule)
-        pattern = urljoin(base=base_url, url=path_to_match)
-        # Anchor the end of the path so that a rule such as ``/api`` matches
-        # only the exact path and not arbitrary suffixes such as
-        # ``/api-extra``.  An optional query string is still allowed.
-        patterns = [pattern]
-        if path_to_match == "/":
-            patterns.append(pattern.rstrip("/"))
+        paths_to_match = [path_to_match]
+        if rule.strict_slashes and path_to_match.endswith("/") and path_to_match != "/":
+            paths_to_match.append(path_to_match.rstrip("/"))
         urls = tuple(
-            re.compile(pattern=path_pattern + r"(\?.*)?$")
-            for path_pattern in patterns
+            re.compile(
+                pattern=urljoin(base=base_url, url=path) + r"(\?.*)?$",
+            )
+            for path in paths_to_match
         )
 
         methods = (rule.methods or set()) | _KNOWN_HTTP_METHODS

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -181,19 +181,20 @@ def add_flask_app_to_mock(
         # should still be forwarded to the Flask app so that it can produce the
         # appropriate response (e.g. a 404). Literal parts are kept literal.
         path_to_match = _rule_to_path_regex(rule=rule)
-        paths_to_match = [path_to_match]
+        patterns = [urljoin(base=base_url, url=path_to_match)]
         has_slashless_redirect = (
             rule.strict_slashes
             and path_to_match.endswith("/")
             and path_to_match != "/"
         )
-        if has_slashless_redirect:
-            paths_to_match.append(path_to_match.rstrip("/"))
-        urls = tuple(
-            re.compile(
-                pattern=urljoin(base=base_url, url=path) + r"(\?.*)?$",
+        if path_to_match == "/":
+            patterns.append(patterns[0].rstrip("/"))
+        elif has_slashless_redirect:
+            patterns.append(
+                urljoin(base=base_url, url=path_to_match.rstrip("/"))
             )
-            for path in paths_to_match
+        urls = tuple(
+            re.compile(pattern=pattern + r"(\?.*)?$") for pattern in patterns
         )
 
         methods = (rule.methods or set()) | _KNOWN_HTTP_METHODS

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -182,7 +182,12 @@ def add_flask_app_to_mock(
         # appropriate response (e.g. a 404). Literal parts are kept literal.
         path_to_match = _rule_to_path_regex(rule=rule)
         paths_to_match = [path_to_match]
-        if rule.strict_slashes and path_to_match.endswith("/") and path_to_match != "/":
+        has_slashless_redirect = (
+            rule.strict_slashes
+            and path_to_match.endswith("/")
+            and path_to_match != "/"
+        )
+        if has_slashless_redirect:
             paths_to_match.append(path_to_match.rstrip("/"))
         urls = tuple(
             re.compile(

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1856,7 +1856,8 @@ def test_missing_trailing_slash_redirect(mock_ctx: _MockCtxType) -> None:
         """Return a simple message."""
         return "Hello, World!"
 
-    response = app.test_client().get("/folder", follow_redirects=False)
+    test_client = app.test_client()
+    response = test_client.get("/folder", follow_redirects=False)
     expected_status_code = HTTPStatus.PERMANENT_REDIRECT
     expected_location_suffix = "/folder/"
     assert response.status_code == expected_status_code

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -67,14 +67,21 @@ def _do_get(
     mock_obj: _MockObjType,
     url: str,
     headers: dict[str, str] | None = None,
+    allow_redirects: bool = True,
 ) -> requests.Response | httpx.Response:
     """Make a GET request via the appropriate HTTP client."""
     if isinstance(mock_obj, (respx.MockRouter, respx.Router)):
-        return httpx.get(url=url, headers=headers, timeout=_TIMEOUT_SECONDS)
+        return httpx.get(
+            url=url,
+            headers=headers,
+            timeout=_TIMEOUT_SECONDS,
+            follow_redirects=allow_redirects,
+        )
     return requests.get(
         url=url,
         headers=headers,
         timeout=_TIMEOUT_SECONDS,
+        allow_redirects=allow_redirects,
     )
 
 
@@ -1837,3 +1844,36 @@ def test_call_on_close_runs(mock_ctx: _MockCtxType) -> None:
         assert mock_response.text == "ok"
 
     assert events == ["closed"]
+
+
+@_MOCK_CTX_MARKER
+def test_missing_trailing_slash_redirect(mock_ctx: _MockCtxType) -> None:
+    """A missing trailing slash is forwarded for Flask to redirect."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/folder/")
+    def _() -> str:
+        """Return a simple message."""
+        return "Hello, World!"
+
+    response = app.test_client().get("/folder", follow_redirects=False)
+    expected_status_code = HTTPStatus.PERMANENT_REDIRECT
+    expected_location_suffix = "/folder/"
+    assert response.status_code == expected_status_code
+    assert response.headers["Location"].endswith(expected_location_suffix)
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com/folder",
+            allow_redirects=False,
+        )
+
+    assert mock_response.status_code == expected_status_code
+    assert mock_response.headers["Location"].endswith(expected_location_suffix)

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1877,3 +1877,6 @@ def test_missing_trailing_slash_redirect(mock_ctx: _MockCtxType) -> None:
 
     assert mock_response.status_code == expected_status_code
     assert mock_response.headers["Location"].endswith(expected_location_suffix)
+
+    direct_response = test_client.get("/folder/")
+    assert direct_response.data == b"Hello, World!"


### PR DESCRIPTION
Closes #1835.

Flask redirects a request for the slashless URL to a slash-terminated route with a 308, but `add_flask_app_to_mock` only registered the literal slash-terminated URL, so every mock back end rejected the slashless request before Flask could redirect.

This registers the slashless counterpart for slash-terminated rules (respecting Werkzeug `strict_slashes`, skipping the root `/`) so the request reaches Flask and Flask produces its 308 redirect, across all four back ends (responses, requests_mock, httpretty, respx).

Adds a parametrized test asserting GET `/folder` (without following redirects) returns 308 to `/folder/` on each back end, plus a newsfragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow routing-registration change with targeted tests; no auth or data handling impact.
> 
> **Overview**
> **`add_flask_app_to_mock`** now registers an extra mock URL for slash-terminated routes (when Werkzeug **`strict_slashes`** applies and the path is not `/`), so requests like `/folder` reach Flask instead of being rejected by the mock layer. Flask can then return its usual **308** redirect to `/folder/`.
> 
> Test helpers gain **`allow_redirects`** on GET, and a parametrized test asserts **308** + **Location** across all mock backends. A newsfragment documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70fd22467405663005ab927c5a834f15c560ab56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->