### PR TITLE
fix: Preserve duplicate request cookies with the same name

### DIFF
--- a/newsfragments/1839.change.rst
+++ b/newsfragments/1839.change.rst
@@ -1,0 +1,1 @@
+Duplicate request cookies with the same name are now preserved instead of being collapsed to the last value.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -3,7 +3,6 @@
 import dataclasses
 import re
 from collections.abc import Callable
-from http.cookies import SimpleCookie
 from types import ModuleType
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
@@ -190,26 +189,12 @@ def _responses_callback(
     :return: A tuple of status code, response headers and response data
         from the flask app.
     """
-    test_client = flask_app.test_client()
+    # We disable the test client's cookie jar so that the original ``Cookie``
+    # header is forwarded to the Flask app untouched. This preserves duplicate
+    # cookies with the same name and other multi-value header semantics.
+    test_client = flask_app.test_client(use_cookies=False)
     # See parameters at
     # https://werkzeug.palletsprojects.com/en/0.15.x/test/#werkzeug.test.EnvironBuilder
-    cookie_dict = dict(request.headers)
-    cookie_string = cookie_dict.get("Cookie", "")
-    cookie_list = cookie_string.split(sep=";")
-    cookie_list_no_empty = [item for item in cookie_list if item]
-    simple_cookie: SimpleCookie = SimpleCookie()
-    for cookie in cookie_list_no_empty:
-        simple_cookie.load(rawdata=cookie)
-
-    cookies_dict = {k: v.value for k, v in simple_cookie.items()}
-
-    for key, value in cookies_dict.items():
-        test_client.set_cookie(
-            domain="localhost",
-            key=key,
-            value=value,
-        )
-
     environ_overrides: dict[str, str] = {}
     if "Content-Length" in request.headers:
         environ_overrides["CONTENT_LENGTH"] = request.headers["Content-Length"]
@@ -251,25 +236,12 @@ def _httpretty_callback(
     del uri
     del headers
 
-    test_client = flask_app.test_client()
+    # We disable the test client's cookie jar so that the original ``Cookie``
+    # header is forwarded to the Flask app untouched. This preserves duplicate
+    # cookies with the same name and other multi-value header semantics.
+    test_client = flask_app.test_client(use_cookies=False)
     # See parameters at
     # https://werkzeug.palletsprojects.com/en/0.15.x/test/#werkzeug.test.EnvironBuilder
-    cookie_string = request.headers.get(name="Cookie", failobj="")
-    cookie_list = cookie_string.split(sep=";")
-    cookie_list_no_empty = [item for item in cookie_list if item]
-    simple_cookie: SimpleCookie = SimpleCookie()
-    for cookie in cookie_list_no_empty:
-        simple_cookie.load(rawdata=cookie)
-
-    cookies_dict = {k: v.value for k, v in simple_cookie.items()}
-
-    for key, value in cookies_dict.items():
-        test_client.set_cookie(
-            domain=request.host,
-            key=key,
-            value=value,
-        )
-
     environ_overrides: dict[str, str] = {}
     if "Content-Length" in request.headers:
         environ_overrides["CONTENT_LENGTH"] = request.headers["Content-Length"]
@@ -303,25 +275,12 @@ def _requests_mock_callback(
     :return: A tuple of status code, response headers and response data
         from the flask app.
     """
-    test_client = flask_app.test_client()
+    # We disable the test client's cookie jar so that the original ``Cookie``
+    # header is forwarded to the Flask app untouched. This preserves duplicate
+    # cookies with the same name and other multi-value header semantics.
+    test_client = flask_app.test_client(use_cookies=False)
     # See parameters at
     # https://werkzeug.palletsprojects.com/en/0.15.x/test/#werkzeug.test.EnvironBuilder
-    cookie_string = request.headers.get("Cookie", "")
-    cookie_list = cookie_string.split(";")
-    cookie_list_no_empty = [item for item in cookie_list if item]
-    simple_cookie: SimpleCookie = SimpleCookie()
-    for cookie in cookie_list_no_empty:
-        simple_cookie.load(rawdata=cookie)
-
-    cookies_dict = {k: v.value for k, v in simple_cookie.items()}
-
-    for key, value in cookies_dict.items():
-        test_client.set_cookie(
-            domain="localhost",
-            key=key,
-            value=value,
-        )
-
     environ_overrides: dict[str, str] = {}
     if "Content-Length" in request.headers:
         environ_overrides["CONTENT_LENGTH"] = request.headers["Content-Length"]

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1080,6 +1080,47 @@ def test_cookies(mock_ctx: _MockCtxType) -> None:
 
 
 @_MOCK_CTX_MARKER
+def test_duplicate_cookies(mock_ctx: _MockCtxType) -> None:
+    """Duplicate cookies with the same name are preserved."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/", methods=["GET"])
+    def _() -> Response:
+        """Return the duplicate cookie values and the raw ``Cookie``
+        header.
+        """
+        assert request.cookies.getlist(key="id") == ["one", "two"]
+        assert request.headers["Cookie"] == "id=one; id=two"
+        return make_response()
+
+    headers = {"Cookie": "id=one; id=two"}
+
+    test_client = app.test_client(use_cookies=False)
+    response = test_client.get("/", headers=headers)
+
+    expected_status_code = HTTPStatus.OK
+
+    assert response.status_code == expected_status_code, response.data
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com",
+            headers=headers,
+        )
+
+    assert mock_response.status_code == expected_status_code
+
+
+@_MOCK_CTX_MARKER
 def test_no_content_type(mock_ctx: _MockCtxType) -> None:
     """It is possible to get a response without a content type."""
     app = Flask(import_name=__name__, static_folder=None)


### PR DESCRIPTION
Closes #1839.

The responses, requests-mock, and HTTPretty callbacks reparsed the incoming `Cookie` header with `SimpleCookie` and rebuilt it through the test client's cookie jar, collapsing duplicate cookie names to the last value. They now disable the cookie jar (`use_cookies=False`) and forward the original `Cookie` header untouched, so Flask sees duplicate cookies (e.g. `request.cookies.getlist("id") == ["one", "two"]`) and the raw header, matching respx's existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to test-client cookie handling in three callbacks; behavior fix with a dedicated regression test and no auth or production runtime impact.
> 
> **Overview**
> **Duplicate `Cookie` header values** (e.g. `id=one; id=two`) are no longer collapsed when mocked HTTP clients forward requests into Flask.
> 
> The **responses**, **requests-mock**, and **HTTPretty** bridge paths used to parse the incoming `Cookie` header with `SimpleCookie`, push values through the Flask test client’s cookie jar, and only keep one value per name. They now create the test client with **`use_cookies=False`** and pass headers through **`EnvironBuilder`**, so the raw `Cookie` header reaches the app—aligned with **respx**’s existing WSGI transport behavior.
> 
> A parametrized test asserts `request.cookies.getlist("id")` and the raw header under each mock backend; a newsfragment records the user-visible fix (closes #1839).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff5b4a437fea44f21c3a52138d95a35a525022ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->