### PR TITLE
fix: Normalize case-insensitive URL components in base_url

### DIFF
--- a/newsfragments/1838.change.rst
+++ b/newsfragments/1838.change.rst
@@ -1,0 +1,1 @@
+The scheme and host of ``base_url`` are now normalized to lowercase so that requests to case-insensitive URL components are intercepted.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -118,7 +118,7 @@ def _normalize_base_url(*, base_url: str) -> str:
 
     HTTP clients normalize the scheme and host to lowercase before matching
     requests, so a ``base_url`` with uppercase scheme or host characters would
-    otherwise register matchers that no client can reach. The userinfo, path
+    otherwise register patterns that no client can reach. The user information, path
     and query components retain their original case.
     """
     parts = urlsplit(url=base_url)

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -116,7 +116,8 @@ def _register_mock(
 def _normalize_base_url(*, base_url: str) -> str:
     """Lowercase the case-insensitive scheme and host of ``base_url``.
 
-    HTTP clients normalize the scheme and host to lowercase before matching
+    HTTP clients normalize the scheme and host to lowercase before
+    matching
     requests, so a ``base_url`` with uppercase scheme or host characters would
     otherwise register patterns that no client can reach. The user information, path
     and query components retain their original case.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -116,11 +116,10 @@ def _register_mock(
 def _normalize_base_url(*, base_url: str) -> str:
     """Lowercase the case-insensitive scheme and host of ``base_url``.
 
-    HTTP clients normalize the scheme and host to lowercase before
-    matching
-    requests, so a ``base_url`` with uppercase scheme or host characters would
-    otherwise register patterns that no client can reach. The user information, path
-    and query components retain their original case.
+    HTTP clients normalize the scheme and host to lowercase before matching
+    requests, so a ``base_url`` with uppercase scheme or host characters
+    would otherwise register patterns that no client can reach. The user
+    information, path and query components retain their original case.
     """
     parts = urlsplit(url=base_url)
     userinfo, separator, hostport = parts.netloc.rpartition("@")

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -5,7 +5,7 @@ import re
 from collections.abc import Callable
 from types import ModuleType
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import httpretty
 import httpx
@@ -113,6 +113,28 @@ def _register_mock(
             raise TypeError(msg)
 
 
+def _normalize_base_url(*, base_url: str) -> str:
+    """Lowercase the case-insensitive scheme and host of ``base_url``.
+
+    HTTP clients normalize the scheme and host to lowercase before matching
+    requests, so a ``base_url`` with uppercase scheme or host characters would
+    otherwise register matchers that no client can reach. The userinfo, path
+    and query components retain their original case.
+    """
+    parts = urlsplit(url=base_url)
+    userinfo, separator, hostport = parts.netloc.rpartition("@")
+    netloc = userinfo + separator + hostport.lower()
+    return urlunsplit(
+        components=(
+            parts.scheme.lower(),
+            netloc,
+            parts.path,
+            parts.query,
+            parts.fragment,
+        )
+    )
+
+
 def add_flask_app_to_mock(
     mock_obj: _MockObjType,
     flask_app: "flask.Flask",
@@ -123,6 +145,7 @@ def add_flask_app_to_mock(
     the
     ``Flask`` app, when in the context of the ``mock_obj``.
     """
+    base_url = _normalize_base_url(base_url=base_url)
     transport = httpx.WSGITransport(app=flask_app)
 
     def respx_side_effect(

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -276,6 +276,37 @@ def test_binary_response(mock_ctx: _MockCtxType) -> None:
 
 
 @_MOCK_CTX_MARKER
+def test_uppercase_base_url_host(mock_ctx: _MockCtxType) -> None:
+    """A ``base_url`` with an uppercase host is matched case-insensitively."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/ping")
+    def _() -> str:
+        """Return a simple message."""
+        return "pong"
+
+    expected_status_code = HTTPStatus.OK
+    expected_data = b"pong"
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://EXAMPLE.COM",
+        )
+
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://example.com/ping",
+        )
+
+    assert mock_response.status_code == expected_status_code
+    assert mock_response.text == expected_data.decode()
+
+
+@_MOCK_CTX_MARKER
 def test_headers(mock_ctx: _MockCtxType) -> None:
     """Request headers are sent."""
     app = Flask(import_name=__name__, static_folder=None)


### PR DESCRIPTION
Closes #1838.

Parse and normalize the scheme and host of `base_url` to lowercase before compiling matchers, so a base URL with uppercase host/scheme characters (e.g. `http://EXAMPLE.COM`) is reachable by HTTP clients that lowercase those components. Path, query, and userinfo retain their original case.

Adds a focused test asserting `http://EXAMPLE.COM` intercepts `http://example.com/ping` across all four backends, plus a newsfragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized URL normalization at registration time with a dedicated test; no auth or data-path changes.
> 
> **Overview**
> Fixes mock registration when **`base_url`** uses uppercase **scheme** or **host** (e.g. `http://EXAMPLE.COM`), which HTTP clients normalize to lowercase before matching.
> 
> **`add_flask_app_to_mock`** now runs **`base_url`** through **`_normalize_base_url`** before building route patterns. That helper lowercases only the scheme and the host/port part of netloc (after any `@` userinfo); path, query, fragment, and userinfo keep their original case.
> 
> Adds **`test_uppercase_base_url_host`** across responses, requests_mock, httpretty, and respx, plus a newsfragment for #1838.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9946ef80a908eb8c633752870b743dcfebfe0fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->