### PR TITLE
fix: Preserve valueless cookie tokens in forwarded requests

### DIFF
--- a/newsfragments/1840.change.rst
+++ b/newsfragments/1840.change.rst
@@ -1,0 +1,1 @@
+Forward the original ``Cookie`` header verbatim so valueless cookie tokens are preserved in forwarded requests.

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1165,6 +1165,48 @@ def test_duplicate_cookies(mock_ctx: _MockCtxType) -> None:
 
 
 @_MOCK_CTX_MARKER
+def test_valueless_cookie_token(mock_ctx: _MockCtxType) -> None:
+    """A valueless cookie token is forwarded without changing its
+    header.
+    """
+    app = Flask(import_name=__name__, static_folder=None)
+    cookie_header = "good=1; valueless; second=2"
+
+    @app.route(rule="/")
+    def _() -> Response:
+        """Return the parsed cookies and raw request header."""
+        return jsonify(
+            {
+                "pairs": list(request.cookies.items(multi=True)),
+                "raw": request.headers.get(key="Cookie"),
+            }
+        )
+
+    test_client = app.test_client(use_cookies=False)
+    response = test_client.get("/", headers={"Cookie": cookie_header})
+    expected_pairs = [["good", "1"], ["valueless", ""], ["second", "2"]]
+    assert response.json == {"pairs": expected_pairs, "raw": cookie_header}
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com",
+            headers={"Cookie": cookie_header},
+        )
+
+    assert mock_response.json() == {
+        "pairs": expected_pairs,
+        "raw": cookie_header,
+    }
+
+
+@_MOCK_CTX_MARKER
 def test_no_content_type(mock_ctx: _MockCtxType) -> None:
     """It is possible to get a response without a content type."""
     app = Flask(import_name=__name__, static_folder=None)


### PR DESCRIPTION
Closes #1840.

The responses, requests_mock, and httpretty callbacks reparsed the `Cookie` header token-by-token with `SimpleCookie` and rebuilt it, silently dropping valueless tokens (no `=`) that Werkzeug keeps as empty-valued cookies. This forwards the original `Cookie` header verbatim via the EnvironBuilder headers, disabling the test client's cookie jar with `use_cookies=False`, so Flask sees exactly what a live WSGI request would. Adds a focused test asserting `good=1; valueless; second=2` yields all three cookies (valueless empty) with the raw header intact across all four backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to how incoming Cookie headers are forwarded in test/mocking paths, with regression coverage and no auth or data-model impact.
> 
> **Overview**
> Fixes **valueless cookie tokens** (e.g. `valueless` with no `=`) being dropped when HTTP mocks forward requests into Flask. The forwarded **`Cookie` header is passed through verbatim** (with the test client cookie jar disabled) so Werkzeug sees the same header as a real WSGI request.
> 
> Adds **`test_valueless_cookie_token`**, parametrized across **responses**, **requests_mock**, **httpretty**, and **respx**, asserting `good=1; valueless; second=2` yields three parsed pairs (valueless as empty) and an unchanged raw header. Includes a **newsfragment** for #1840.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 113d78151b64fa46a8c53868f23694cbe6ee723e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->