### PR TITLE
fix: Close forwarded Flask responses so call_on_close callbacks run

### DIFF
--- a/newsfragments/1848.change.rst
+++ b/newsfragments/1848.change.rst
@@ -1,0 +1,1 @@
+Forwarded Flask responses are now closed so ``call_on_close`` callbacks run.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -263,10 +263,12 @@ def _responses_callback(
         environ_overrides=environ_overrides,
     )
 
-    response = test_client.open(environ_builder.get_request())
-
-    response_headers = HTTPHeaderDict(headers=response.headers)
-    return (response.status_code, response_headers, bytes(response.data))
+    with test_client.open(environ_builder.get_request()) as response:
+        return (
+            response.status_code,
+            HTTPHeaderDict(headers=response.headers),
+            bytes(response.data),
+        )
 
 
 def _httpretty_callback(
@@ -311,10 +313,12 @@ def _httpretty_callback(
         data=request.body,
         environ_overrides=environ_overrides,
     )
-    response = test_client.open(environ_builder.get_request())
-
-    response_headers = HTTPHeaderDict(headers=response.headers)
-    return (response.status_code, response_headers, response.data)
+    with test_client.open(environ_builder.get_request()) as response:
+        return (
+            response.status_code,
+            HTTPHeaderDict(headers=response.headers),
+            response.data,
+        )
 
 
 def _requests_mock_callback(
@@ -353,10 +357,9 @@ def _requests_mock_callback(
         data=request.body,
         environ_overrides=environ_overrides,
     )
-    response = test_client.open(environ_builder.get_request())
-
-    # requests-mock exposes headers as ``dict[str, str]``, so its callback
-    # context cannot represent repeated fields.
-    context.headers = dict(response.headers)
-    context.status_code = response.status_code
-    return bytes(response.data)
+    with test_client.open(environ_builder.get_request()) as response:
+        # requests-mock exposes headers as ``dict[str, str]``, so its callback
+        # context cannot represent repeated fields.
+        context.headers = dict(response.headers)
+        context.status_code = response.status_code
+        return bytes(response.data)

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1731,3 +1731,32 @@ def test_preserve_host_and_scheme(mock_ctx: _MockCtxType) -> None:
         "scheme": "https",
         "secure": True,
     }
+
+
+@_MOCK_CTX_MARKER
+def test_call_on_close_runs(mock_ctx: _MockCtxType) -> None:
+    """Response close callbacks run after the forwarded response is consumed."""
+    events: list[str] = []
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/")
+    def _() -> Response:
+        """Return a response with a close callback."""
+        response = Response(response="ok")
+        response.call_on_close(func=lambda: events.append("closed"))
+        return response
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com",
+        )
+        assert mock_response.text == "ok"
+
+    assert events == ["closed"]

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1735,7 +1735,9 @@ def test_preserve_host_and_scheme(mock_ctx: _MockCtxType) -> None:
 
 @_MOCK_CTX_MARKER
 def test_call_on_close_runs(mock_ctx: _MockCtxType) -> None:
-    """Response close callbacks run after the forwarded response is consumed."""
+    """Response close callbacks run after the forwarded response is
+    consumed.
+    """
     events: list[str] = []
     app = Flask(import_name=__name__, static_folder=None)
 


### PR DESCRIPTION
Closes #1848.

The responses, requests-mock, and HTTPretty callbacks read the Flask test response body and returned without closing the response, so functions registered with `Response.call_on_close()` never ran (unlike a completed WSGI response). Each callback now uses the Flask test response as a context manager, closing it reliably after status/headers/body are captured. Adds a parametrized test asserting the callback runs on every backend, plus a newsfragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix in test forwarding paths; behavior change only affects apps relying on close callbacks, with regression coverage across mock backends.
> 
> **Overview**
> Forwarded Flask app responses through **responses**, **requests-mock**, and **HTTPretty** now use `test_client.open(...)` as a context manager so the test response is **closed** after status, headers, and body are read. That aligns mocked forwarding with a finished WSGI response and lets **`Response.call_on_close()`** callbacks run.
> 
> A parametrized test asserts the close callback fires on each of those backends, and a newsfragment documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d528ee01770291ded7386408a5c49ffe66908f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->