### PR TITLE
fix: Normalize internationalized base_url hostnames to IDNA

### DIFF
--- a/newsfragments/1847.change.rst
+++ b/newsfragments/1847.change.rst
@@ -1,0 +1,1 @@
+Internationalized ``base_url`` hostnames are now normalized to their IDNA/Punycode form so that internationalized routes are intercepted.

--- a/newsfragments/1847.change.rst
+++ b/newsfragments/1847.change.rst
@@ -1,1 +1,1 @@
-Internationalized ``base_url`` hostnames are now normalized to their IDNA/Punycode form so that internationalized routes are intercepted.
+Internationalized ``base_url`` host names are now normalized to their IDNA form so that internationalized routes are intercepted.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -70,7 +70,7 @@ def _host_rule_matches_base_url(
             converter = rule_converters[data]
             host_parts.append(f"(?:{converter.regex})")
         else:
-            host_parts.append(re.escape(pattern=data))
+            host_parts.append(re.escape(pattern=_host_to_idna(host=data)))
 
     host_pattern = "".join(host_parts)
     return re.fullmatch(pattern=host_pattern, string=base_url_host) is not None
@@ -160,7 +160,17 @@ def _normalize_base_url(*, base_url: str) -> str:
     )
 
 
-def _normalize_base_url_host_to_idna(base_url: str) -> str:
+def _host_to_idna(*, host: str) -> str:
+    """Return an internationalized host in ASCII IDNA form."""
+    if host.isascii() or ":" in host:
+        return host
+    return ".".join(
+        label.encode(encoding="idna").decode(encoding="ascii") if label else ""
+        for label in host.split(sep=".")
+    )
+
+
+def _normalize_base_url_host_to_idna(*, base_url: str) -> str:
     """
     Return ``base_url`` with any internationalized host encoded using
     IDNA.
@@ -176,19 +186,15 @@ def _normalize_base_url_host_to_idna(base_url: str) -> str:
     host = split.hostname
     if host is None:
         return base_url
-    if ":" in host:
+    idna_host = _host_to_idna(host=host)
+    if idna_host == host:
         return base_url
 
-    idna_host = host.encode(encoding="idna").decode(encoding="ascii")
-    netloc = idna_host
-    if split.port is not None:
-        netloc = f"{netloc}:{split.port}"
-    if split.username is not None:
-        userinfo = split.username
-        if split.password is not None:
-            userinfo = f"{userinfo}:{split.password}"
-        netloc = f"{userinfo}@{netloc}"
-    return split._replace(netloc=netloc).geturl()
+    userinfo, separator, hostport = split.netloc.rpartition("@")
+    normalized_hostport = idna_host + hostport[len(host) :]
+    normalized_netloc = userinfo + separator + normalized_hostport
+    prefix, _, suffix = base_url.partition(split.netloc)
+    return prefix + normalized_netloc + suffix
 
 
 def add_flask_app_to_mock(

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -188,7 +188,8 @@ def _normalize_base_url_host_to_idna(*, base_url: str) -> str:
         return base_url
 
     userinfo, separator, hostport = split.netloc.rpartition("@")
-    normalized_hostport = idna_host + hostport[len(host) :]
+    _, port_separator, port = hostport.partition(":")
+    normalized_hostport = idna_host + port_separator + port
     normalized_netloc = userinfo + separator + normalized_hostport
     prefix, _, suffix = base_url.partition(split.netloc)
     return prefix + normalized_netloc + suffix

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -165,8 +165,8 @@ def _normalize_base_url_host_to_idna(base_url: str) -> str:
     Return ``base_url`` with any internationalized host encoded using
     IDNA.
 
-    HTTP clients convert Unicode hostnames to their ASCII IDNA/Punycode form
-    before sending a request, so the registered matcher must use the same
+    HTTP clients convert Unicode host names to their ASCII IDNA form
+    before sending a request, so the registered pattern must use the same
     ASCII form in order to intercept those requests.
     """
     if base_url.isascii():

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -176,6 +176,8 @@ def _normalize_base_url_host_to_idna(base_url: str) -> str:
     host = split.hostname
     if host is None:
         return base_url
+    if ":" in host:
+        return base_url
 
     idna_host = host.encode(encoding="idna").decode(encoding="ascii")
     netloc = idna_host

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -160,6 +160,35 @@ def _normalize_base_url(*, base_url: str) -> str:
     )
 
 
+def _normalize_base_url_host_to_idna(base_url: str) -> str:
+    """
+    Return ``base_url`` with any internationalized host encoded using
+    IDNA.
+
+    HTTP clients convert Unicode hostnames to their ASCII IDNA/Punycode form
+    before sending a request, so the registered matcher must use the same
+    ASCII form in order to intercept those requests.
+    """
+    if base_url.isascii():
+        return base_url
+
+    split = urlsplit(url=base_url)
+    host = split.hostname
+    if host is None:
+        return base_url
+
+    idna_host = host.encode(encoding="idna").decode(encoding="ascii")
+    netloc = idna_host
+    if split.port is not None:
+        netloc = f"{netloc}:{split.port}"
+    if split.username is not None:
+        userinfo = split.username
+        if split.password is not None:
+            userinfo = f"{userinfo}:{split.password}"
+        netloc = f"{userinfo}@{netloc}"
+    return split._replace(netloc=netloc).geturl()
+
+
 def add_flask_app_to_mock(
     mock_obj: _MockObjType,
     flask_app: "flask.Flask",
@@ -171,6 +200,7 @@ def add_flask_app_to_mock(
     ``Flask`` app, when in the context of the ``mock_obj``.
     """
     base_url = _normalize_base_url(base_url=base_url)
+    base_url = _normalize_base_url_host_to_idna(base_url=base_url)
     transport = httpx.WSGITransport(app=flask_app)
 
     def respx_side_effect(

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -179,9 +179,6 @@ def _normalize_base_url_host_to_idna(*, base_url: str) -> str:
     before sending a request, so the registered pattern must use the same
     ASCII form in order to intercept those requests.
     """
-    if base_url.isascii():
-        return base_url
-
     split = urlsplit(url=base_url)
     host = split.hostname
     if host is None:

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -362,8 +362,8 @@ def test_binary_response(mock_ctx: _MockCtxType) -> None:
 
 
 @pytest.mark.parametrize(
-    ("base_url", "expected_url"),
-    [
+    argnames=("base_url", "expected_url"),
+    argvalues=[
         ("a-path-with-é", "a-path-with-é"),
         (
             "http://user:pass@münich.example:8080",

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -362,6 +362,7 @@ def test_binary_response(mock_ctx: _MockCtxType) -> None:
     argnames="base_url",
     argvalues=[
         "a-path-with-é",
+        "http://[::1]/café",
         "http://user:pass@münich.example:8080",
         "http://user@münich.example",
     ],

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -26,7 +26,10 @@ from requests_mock.exceptions import NoMockAddress
 from respx.models import AllMockedAssertionError
 from werkzeug.routing import BaseConverter, Map
 
-from requests_mock_flask import add_flask_app_to_mock
+from requests_mock_flask import (
+    _normalize_base_url_host_to_idna,
+    add_flask_app_to_mock,
+)
 
 # We use a high timeout to allow interactive debugging while requests are being
 # made.
@@ -356,6 +359,24 @@ def test_binary_response(mock_ctx: _MockCtxType) -> None:
     assert mock_response.status_code == expected_status_code
     assert mock_response.headers["Content-Type"] == expected_content_type
     assert mock_response.content == expected_data
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected_url"),
+    [
+        ("a-path-with-é", "a-path-with-é"),
+        (
+            "http://user:pass@münich.example:8080",
+            "http://user:pass@xn--mnich-kva.example:8080",
+        ),
+    ],
+)
+def test_normalize_base_url_host_to_idna(
+    base_url: str,
+    expected_url: str,
+) -> None:
+    """IDNA normalization preserves the non-host URL components."""
+    assert _normalize_base_url_host_to_idna(base_url=base_url) == expected_url
 
 
 @_MOCK_CTX_MARKER

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -363,6 +363,7 @@ def test_binary_response(mock_ctx: _MockCtxType) -> None:
     argvalues=[
         "a-path-with-é",
         "http://[::1]/café",
+        "http://example.com:invalid/café",
         "http://user:pass@münich.example:8080",
         "http://user@münich.example",
     ],
@@ -2178,3 +2179,22 @@ def test_internationalized_base_url(mock_ctx: _MockCtxType) -> None:
 
     assert mock_response.status_code == HTTPStatus.OK
     assert mock_response.text == "Hello, World!"
+
+
+def test_internationalized_host_rule_is_registered() -> None:
+    """A Unicode host rule applies to its IDNA-normalized base URL."""
+    app = Flask(import_name=__name__, host_matching=True, static_folder=None)
+    app.add_url_rule(
+        rule="/",
+        endpoint="internationalized",
+        host="münich.example",
+    )
+
+    mock_obj = responses.RequestsMock()
+    add_flask_app_to_mock(
+        mock_obj=mock_obj,
+        flask_app=app,
+        base_url="http://münich.example",
+    )
+
+    assert mock_obj.registered()

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -2131,3 +2131,27 @@ def test_host_matching_rule_registered_for_matching_host(
 
     assert mock_response.status_code == HTTPStatus.OK
     assert mock_response.text == "Hello, World!"
+
+
+@_MOCK_CTX_MARKER
+def test_internationalized_base_url(mock_ctx: _MockCtxType) -> None:
+    """A Unicode base URL host is registered in its ASCII IDNA form."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/")
+    def _() -> str:
+        """Return a simple message."""
+        return "Hello, World!"
+
+    base_url = "http://münich.example"
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url=base_url,
+        )
+        mock_response = _do_get(mock_obj=mock_obj_to_add, url=base_url)
+
+    assert mock_response.status_code == HTTPStatus.OK
+    assert mock_response.text == "Hello, World!"

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -369,7 +369,9 @@ def test_binary_response(mock_ctx: _MockCtxType) -> None:
 def test_idna_normalization_accepts_non_host_url_components(
     base_url: str,
 ) -> None:
-    """IDNA normalization accepts credentials, ports, and hostless URLs."""
+    """IDNA normalization accepts credentials, ports, and hostless
+    URLs.
+    """
     app = Flask(import_name=__name__, static_folder=None)
     add_flask_app_to_mock(
         mock_obj=responses.RequestsMock(),

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -370,8 +370,8 @@ def test_binary_response(mock_ctx: _MockCtxType) -> None:
 def test_idna_normalization_accepts_non_host_url_components(
     base_url: str,
 ) -> None:
-    """IDNA normalization accepts credentials, ports, and hostless
-    URLs.
+    """IDNA normalization accepts credentials, ports, and URLs without
+    hosts.
     """
     app = Flask(import_name=__name__, static_folder=None)
     add_flask_app_to_mock(

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -2157,8 +2157,18 @@ def test_host_matching_rule_registered_for_matching_host(
     assert mock_response.text == "Hello, World!"
 
 
+@pytest.mark.parametrize(
+    argnames="base_url",
+    argvalues=[
+        pytest.param("http://münich.example", id="unicode"),
+        pytest.param("http://m%C3%BCnich.example", id="percent-encoded"),
+    ],
+)
 @_MOCK_CTX_MARKER
-def test_internationalized_base_url(mock_ctx: _MockCtxType) -> None:
+def test_internationalized_base_url(
+    mock_ctx: _MockCtxType,
+    base_url: str,
+) -> None:
     """A Unicode base URL host is registered in its ASCII IDNA form."""
     app = Flask(import_name=__name__, static_folder=None)
 
@@ -2167,7 +2177,6 @@ def test_internationalized_base_url(mock_ctx: _MockCtxType) -> None:
         """Return a simple message."""
         return "Hello, World!"
 
-    base_url = "http://münich.example"
     with mock_ctx() as mock_obj:
         mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
         add_flask_app_to_mock(

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -26,10 +26,7 @@ from requests_mock.exceptions import NoMockAddress
 from respx.models import AllMockedAssertionError
 from werkzeug.routing import BaseConverter, Map
 
-from requests_mock_flask import (
-    _normalize_base_url_host_to_idna,
-    add_flask_app_to_mock,
-)
+from requests_mock_flask import add_flask_app_to_mock
 
 # We use a high timeout to allow interactive debugging while requests are being
 # made.
@@ -362,21 +359,23 @@ def test_binary_response(mock_ctx: _MockCtxType) -> None:
 
 
 @pytest.mark.parametrize(
-    argnames=("base_url", "expected_url"),
+    argnames="base_url",
     argvalues=[
-        ("a-path-with-é", "a-path-with-é"),
-        (
-            "http://user:pass@münich.example:8080",
-            "http://user:pass@xn--mnich-kva.example:8080",
-        ),
+        "a-path-with-é",
+        "http://user:pass@münich.example:8080",
+        "http://user@münich.example",
     ],
 )
-def test_normalize_base_url_host_to_idna(
+def test_idna_normalization_accepts_non_host_url_components(
     base_url: str,
-    expected_url: str,
 ) -> None:
-    """IDNA normalization preserves the non-host URL components."""
-    assert _normalize_base_url_host_to_idna(base_url=base_url) == expected_url
+    """IDNA normalization accepts credentials, ports, and hostless URLs."""
+    app = Flask(import_name=__name__, static_folder=None)
+    add_flask_app_to_mock(
+        mock_obj=responses.RequestsMock(),
+        flask_app=app,
+        base_url=base_url,
+    )
 
 
 @_MOCK_CTX_MARKER


### PR DESCRIPTION
Closes #1847.

HTTP clients convert Unicode internationalized hostnames to their ASCII IDNA/Punycode form before sending a request, so routes registered for an internationalized `base_url` host could not be intercepted. The host is now encoded with IDNA before the matcher is registered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted URL normalization and host-matching change with tests; no auth or data-handling impact.
> 
> **Overview**
> **Fixes interception of requests to internationalized `base_url` hosts** by aligning registered mock patterns with what HTTP clients actually send (ASCII IDNA/Punycode).
> 
> `add_flask_app_to_mock` now runs **`_normalize_base_url_host_to_idna`** after the existing scheme/host lowercasing, rewriting only the hostname in `netloc` while preserving userinfo, port, path, and query. **`_host_to_idna`** skips ASCII hosts and strings containing `:` (e.g. IPv6). Host-matching for Flask rules applies the same IDNA encoding to literal host segments in **`_host_rule_matches_base_url`**.
> 
> Tests cover Unicode and percent-encoded `münich.example`, host-constrained routes, and that normalization does not break hostless URLs, IPv6 paths, invalid ports, or credentials in the URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbcaa3cab4690f102cbc8c00795a1ae0a916947b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->