### PR TITLE
fix: Percent-encode non-ASCII static route paths when registering mocks

### DIFF
--- a/newsfragments/1836.change.rst
+++ b/newsfragments/1836.change.rst
@@ -1,0 +1,1 @@
+Percent-encode the static portions of route paths so that non-ASCII routes such as ``/café`` are reachable through the mock.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -7,7 +7,7 @@ import re
 from operator import methodcaller
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, BinaryIO
-from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.parse import quote, urljoin, urlsplit, urlunsplit
 
 import httpretty
 import httpx
@@ -361,7 +361,8 @@ def _rule_to_path_regex(rule: Rule) -> str:
             converter = rule_converters[data]
             path_parts.append(converter.regex)
         else:
-            path_parts.append(re.escape(pattern=data))
+            encoded_literal = quote(string=data, safe="/")
+            path_parts.append(re.escape(pattern=encoded_literal))
     return "".join(path_parts)
 
 

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -264,7 +264,10 @@ def add_flask_app_to_mock(
         """
         path_info = environ["PATH_INFO"]
         environ["PATH_INFO"] = path_info.encode().decode("latin-1")
-        return flask_app.wsgi_app(environ, start_response)
+        return flask_app.wsgi_app(
+            environ=environ,
+            start_response=start_response,
+        )
 
     transport = httpx.WSGITransport(app=respx_wsgi_app)
 

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
     import flask
     import requests
+    from _typeshed.wsgi import StartResponse, WSGIEnvironment
     from werkzeug.routing import Rule
 
     type _RequestBody = (
@@ -253,7 +254,19 @@ def add_flask_app_to_mock(
     """
     base_url = _normalize_base_url(base_url=base_url)
     base_url = _normalize_base_url_host_to_idna(base_url=base_url)
-    transport = httpx.WSGITransport(app=flask_app)
+
+    def respx_wsgi_app(
+        environ: "WSGIEnvironment",
+        start_response: "StartResponse",
+    ) -> Iterable[bytes]:
+        """Normalize HTTPX's Unicode path to the WSGI latin-1
+        convention.
+        """
+        path_info = environ["PATH_INFO"]
+        environ["PATH_INFO"] = path_info.encode().decode("latin-1")
+        return flask_app.wsgi_app(environ, start_response)
+
+    transport = httpx.WSGITransport(app=respx_wsgi_app)
 
     def respx_side_effect(
         request: httpx.Request,

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -19,10 +19,10 @@ from urllib3 import HTTPHeaderDict
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
+    from wsgiref.types import StartResponse, WSGIEnvironment
 
     import flask
     import requests
-    from _typeshed.wsgi import StartResponse, WSGIEnvironment
     from werkzeug.routing import Rule
 
     type _RequestBody = (
@@ -256,8 +256,8 @@ def add_flask_app_to_mock(
     base_url = _normalize_base_url_host_to_idna(base_url=base_url)
 
     def respx_wsgi_app(
-        environ: "WSGIEnvironment",
-        start_response: "StartResponse",
+        environ: WSGIEnvironment,
+        start_response: StartResponse,
     ) -> Iterable[bytes]:
         """Normalize HTTPX's Unicode path to the WSGI latin-1
         convention.

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -2371,12 +2371,23 @@ def test_internationalized_host_rule_is_registered() -> None:
     assert mock_obj.registered()
 
 
+@pytest.mark.parametrize(
+    argnames=("route", "url_path"),
+    argvalues=[
+        ("/café", "/café"),
+        ("/literal%2F", "/literal%252F"),
+    ],
+)
 @_MOCK_CTX_MARKER
-def test_non_ascii_route(mock_ctx: _MockCtxType) -> None:
-    """A non-ASCII static route is matched in percent-encoded form."""
+def test_percent_encoded_route(
+    mock_ctx: _MockCtxType,
+    route: str,
+    url_path: str,
+) -> None:
+    """Static routes are matched in their percent-encoded form."""
     app = Flask(import_name=__name__, static_folder=None)
 
-    @app.route(rule="/café")
+    @app.route(rule=route)
     def _() -> str:
         """Return a simple message."""
         return "Hello, World!"
@@ -2390,7 +2401,7 @@ def test_non_ascii_route(mock_ctx: _MockCtxType) -> None:
         )
         mock_response = _do_get(
             mock_obj=mock_obj_to_add,
-            url="http://www.example.com/café",
+            url=f"http://www.example.com{url_path}",
         )
 
     assert mock_response.status_code == HTTPStatus.OK

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -2369,3 +2369,29 @@ def test_internationalized_host_rule_is_registered() -> None:
     )
 
     assert mock_obj.registered()
+
+
+@_MOCK_CTX_MARKER
+def test_non_ascii_route(mock_ctx: _MockCtxType) -> None:
+    """A non-ASCII static route is matched in percent-encoded form."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/café")
+    def _() -> str:
+        """Return a simple message."""
+        return "Hello, World!"
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com/café",
+        )
+
+    assert mock_response.status_code == HTTPStatus.OK
+    assert mock_response.text == "Hello, World!"


### PR DESCRIPTION
Closes #1836.

Flask allows non-ASCII literals in route rules, but the URL regex was compiled from the raw Unicode rule. HTTP clients percent-encode those characters (e.g. `/café` -> `/caf%C3%A9`) before mock matching, so such routes were unreachable through every backend.

- Percent-encode the static portions of each rule when registering mocks, while leaving generated converter placeholders (`.+`, `[^/]+`) as regex patterns.
- Normalize `PATH_INFO` for the respx WSGI transport, which otherwise mis-decodes non-ASCII paths (httpx sets `PATH_INFO` to a fully decoded Unicode string rather than the latin-1 byte string WSGI/PEP 3333 expects).

Adds a parametrized test covering a `/café` route across all four backends (responses, requests-mock, respx, HTTPretty).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted URL-matching and respx PATH_INFO normalization for internationalized static paths; limited scope with new regression tests across mock backends.
> 
> **Overview**
> Fixes mock registration so **static** Flask route literals match URLs as HTTP clients send them (percent-encoded), e.g. `/café` → `/caf%C3%A9`, while dynamic converter segments stay as regex placeholders.
> 
> In **`_rule_to_path_regex`**, literal path pieces are **`quote(..., safe="/")`** then regex-escaped instead of escaping raw Unicode. For **respx/httpx**, a thin WSGI wrapper rewrites **`PATH_INFO`** from httpx’s decoded Unicode back to the latin-1 byte string WSGI expects before calling the Flask app.
> 
> Adds parametrized coverage for `/café` and a literal `%2F` segment across responses, requests-mock, respx, and HTTPretty, plus a changelog newsfragment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f04ce3229889fb71fce89c09a9cd14e4dfd3e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->