### PR TITLE
fix: Anchor route matchers so path prefixes remain unmatched

### DIFF
--- a/newsfragments/1832.change.rst
+++ b/newsfragments/1832.change.rst
@@ -1,0 +1,1 @@
+Route matchers are now anchored so that a rule such as ``/api`` no longer intercepts unrelated paths such as ``/api-extra``, while still matching an optional query string.

--- a/newsfragments/1832.change.rst
+++ b/newsfragments/1832.change.rst
@@ -1,1 +1,1 @@
-Route matchers are now anchored so that a rule such as ``/api`` no longer intercepts unrelated paths such as ``/api-extra``, while still matching an optional query string.
+Route patterns are now anchored so that a rule such as ``/api`` no longer intercepts unrelated paths such as ``/api-extra``, while still matching an optional query string.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -163,7 +163,10 @@ def add_flask_app_to_mock(
             string=path_to_match,
         )
         pattern = urljoin(base=base_url, url=path_to_match)
-        urls = (re.compile(pattern=pattern), re.compile(pattern=pattern + "$"))
+        # Anchor the end of the path so that a rule such as ``/api`` matches
+        # only the exact path and not arbitrary suffixes such as
+        # ``/api-extra``.  An optional query string is still allowed.
+        urls = (re.compile(pattern=pattern + r"(\?.*)?$"),)
 
         methods = rule.methods or set()
         for method in methods:

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -166,7 +166,13 @@ def add_flask_app_to_mock(
         # Anchor the end of the path so that a rule such as ``/api`` matches
         # only the exact path and not arbitrary suffixes such as
         # ``/api-extra``.  An optional query string is still allowed.
-        urls = (re.compile(pattern=pattern + r"(\?.*)?$"),)
+        patterns = [pattern]
+        if path_to_match == "/":
+            patterns.append(pattern.rstrip("/"))
+        urls = tuple(
+            re.compile(pattern=path_pattern + r"(\?.*)?$")
+            for path_pattern in patterns
+        )
 
         methods = rule.methods or set()
         for method in methods:

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -420,45 +420,6 @@ def test_route_with_path_variable_with_slash(mock_ctx: _MockCtxType) -> None:
 
 
 @_MOCK_CTX_MARKER
-def test_route_with_string_variable_with_slash(mock_ctx: _MockCtxType) -> None:
-    """A route with a string variable when given a slash works."""
-    app = Flask(import_name=__name__, static_folder=None)
-
-    @app.route(rule="/<string:my_variable>")
-    def _(_: str) -> str:
-        """Return an empty string."""
-        return ""  # pragma: no cover
-
-    test_client = app.test_client()
-    response = test_client.get("/foo/bar")
-
-    expected_status_code = HTTPStatus.NOT_FOUND
-    expected_content_type = "text/html; charset=utf-8"
-
-    assert response.status_code == expected_status_code
-    assert response.headers["Content-Type"] == expected_content_type
-    assert b"not found on the server" in response.data
-
-    with mock_ctx() as mock_obj:
-        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
-
-        add_flask_app_to_mock(
-            mock_obj=mock_obj_to_add,
-            flask_app=app,
-            base_url="http://www.example.com",
-        )
-
-        mock_response = _do_get(
-            mock_obj=mock_obj_to_add,
-            url="http://www.example.com/foo/bar",
-        )
-
-    assert mock_response.status_code == expected_status_code
-    assert mock_response.headers["Content-Type"] == expected_content_type
-    assert "not found on the server" in mock_response.text
-
-
-@_MOCK_CTX_MARKER
 def test_route_with_uuid_variable(mock_ctx: _MockCtxType) -> None:
     """A route with a uuid variable works."""
     app = Flask(import_name=__name__, static_folder=None)
@@ -1289,6 +1250,115 @@ def test_multiple_variables_rejects_extra_segments(
             _do_get(
                 mock_obj=mock_obj_to_add,
                 url="http://www.example.com/users/cranes/frasier/extra/posts",
+            )
+
+
+@_MOCK_CTX_MARKER
+def test_route_matches_optional_query_string(mock_ctx: _MockCtxType) -> None:
+    """
+    A route such as ``/api`` matches its exact path both with and without a
+    query string.
+    """
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/api")
+    def _() -> str:
+        """Return a simple message."""
+        return "api"
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com/api",
+        )
+        assert mock_response.status_code == HTTPStatus.OK
+        assert mock_response.text == "api"
+
+        query_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com/api?x=1",
+        )
+        assert query_response.status_code == HTTPStatus.OK
+        assert query_response.text == "api"
+
+
+@_MOCK_CTX_MARKER_NO_HTTPRETTY
+def test_route_does_not_match_path_prefix(mock_ctx: _MockCtxType) -> None:
+    """
+    A route such as ``/api`` does not intercept unrelated paths which share
+    its prefix, such as ``/api-extra``.
+    """
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/api")
+    def _() -> str:
+        """Return a simple message."""
+        return "api"  # pragma: no cover
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+
+        expected_exceptions: tuple[type[Exception], ...] = (
+            AllMockedAssertionError,
+            requests.exceptions.ConnectionError,
+            NoMockAddress,
+        )
+        with pytest.raises(expected_exception=expected_exceptions):
+            _do_get(
+                mock_obj=mock_obj_to_add,
+                url="http://www.example.com/api-extra",
+            )
+
+
+@_MOCK_CTX_MARKER_NO_HTTPRETTY
+def test_string_variable_rejects_extra_segments(
+    mock_ctx: _MockCtxType,
+) -> None:
+    """
+    A route with a single string variable does not match URLs with extra
+    path segments.
+    """
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/<string:my_variable>")
+    def _(_: str) -> str:
+        """Return an empty string."""
+        return ""  # pragma: no cover
+
+    # The real Flask app rejects URLs with extra segments.
+    test_client = app.test_client()
+    response = test_client.get("/foo/bar")
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+
+        expected_exceptions: tuple[type[Exception], ...] = (
+            AllMockedAssertionError,
+            requests.exceptions.ConnectionError,
+            NoMockAddress,
+        )
+        with pytest.raises(expected_exception=expected_exceptions):
+            _do_get(
+                mock_obj=mock_obj_to_add,
+                url="http://www.example.com/foo/bar",
             )
 
 

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1256,7 +1256,8 @@ def test_multiple_variables_rejects_extra_segments(
 @_MOCK_CTX_MARKER
 def test_route_matches_optional_query_string(mock_ctx: _MockCtxType) -> None:
     """
-    A route such as ``/api`` matches its exact path both with and without a
+    A route such as ``/api`` matches its exact path both with and
+    without a
     query string.
     """
     app = Flask(import_name=__name__, static_folder=None)
@@ -1292,7 +1293,8 @@ def test_route_matches_optional_query_string(mock_ctx: _MockCtxType) -> None:
 @_MOCK_CTX_MARKER_NO_HTTPRETTY
 def test_route_does_not_match_path_prefix(mock_ctx: _MockCtxType) -> None:
     """
-    A route such as ``/api`` does not intercept unrelated paths which share
+    A route such as ``/api`` does not intercept unrelated paths which
+    share
     its prefix, such as ``/api-extra``.
     """
     app = Flask(import_name=__name__, static_folder=None)


### PR DESCRIPTION
Closes #1832.

Each Flask rule previously registered both an unanchored and an end-anchored regex. The unanchored form let a rule such as `/api` intercept unrelated paths such as `/api-extra` on responses, requests-mock and RESPX, silently returning Flask's 404 instead of letting the backend raise its unmatched-request error.

This change registers a single anchored regex per rule that matches the exact path plus an optional query string. Query-string routes continue to work; extra path segments (e.g. `/api-extra`, or `/foo/bar` against `/<string:var>`) are no longer intercepted. HTTPretty already matched strictly. Added focused tests and a newsfragment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core URL matching for all mock backends (responses, requests-mock, respx); behavior shifts from silently returning Flask 404 on prefix matches to surfacing unmatched-request errors, which may break tests that relied on the old semantics.
> 
> **Overview**
> **Fixes overly broad Flask route registration** in `add_flask_app_to_mock` so mocked HTTP clients behave like strict path matching instead of prefix matching.
> 
> Registration no longer uses a pair of patterns (unanchored + end-anchored). Each rule now gets **one regex** ending in `(\?.*)?$`, so paths like `/api` match only `/api` and `/api?…`, not `/api-extra`. Root rules still register both with and without a trailing slash.
> 
> Tests replace the old “extra segment returns Flask 404 via mock” case with assertions that **unmatched URLs raise** the mock library’s errors, plus coverage for optional query strings and prefix/extra-segment rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16aba0e3752e6e2d7a1f98789ffebc8240e496ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->