### PR TITLE
fix: Declare Flask as a runtime dependency

### DIFF
--- a/newsfragments/1849.change.rst
+++ b/newsfragments/1849.change.rst
@@ -1,0 +1,1 @@
+Flask is now declared as a runtime dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
+    "flask>=2.3",
     "httpretty>=1.1.4",
     "httpx>=0.27.0",
     "requests-mock>=1.12.1",
@@ -300,6 +301,10 @@ ignore = [
 ]
 
 [tool.deptry]
+# Flask is a runtime dependency because the public helper operates on a
+# ``flask.Flask`` application, but it is imported only by callers and tests
+# rather than by the source itself.
+per_rule_ignores.DEP002 = [ "flask" ]
 optional_dependencies_dev_groups = [
     "dev",
     "release",


### PR DESCRIPTION
Closes #1849.

The public helper `add_flask_app_to_mock` operates on a `flask.Flask` application, but Flask was declared only under the `dev` extra. This adds `flask>=2.3` to `[project].dependencies` (consistent with `werkzeug>=2.3`) so a clean install provides the documented API. The built wheel now emits a runtime `Requires-Dist: flask>=2.3`. deptry is configured to ignore DEP002 for Flask since it is imported only by callers and tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no application logic; slightly broadens the default install footprint by pulling in Flask.
> 
> **Overview**
> **Flask is now a required install dependency** (`flask>=2.3`), aligned with the existing `werkzeug>=2.3` pin, so consumers who use the public `add_flask_app_to_mock` helper get Flask without installing the `dev` extra.
> 
> **deptry** is configured to ignore DEP002 for Flask because the library does not import Flask in its own source—only callers and tests do—while the wheel still advertises `Requires-Dist: flask>=2.3`.
> 
> A towncrier fragment records the packaging change for the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d380b9afe921b69f34e7aea251d041e6375f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->