### PR TITLE
fix: Preserve custom HTTP reason phrases from Flask responses

### DIFF
--- a/newsfragments/1843.change.rst
+++ b/newsfragments/1843.change.rst
@@ -1,0 +1,1 @@
+Custom HTTP reason phrases from Flask responses are now preserved for the ``requests_mock`` back end.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -357,6 +357,10 @@ def _requests_mock_callback(
     with test_client.open(environ_builder.get_request()) as response:
         # requests-mock exposes headers as ``dict[str, str]``, so its callback
         # context cannot represent repeated fields.
+        # ``response.status`` is the full WSGI status line, so preserve its
+        # reason phrase through requests-mock's callback context.
+        _, _, reason_phrase = response.status.partition(" ")
         context.headers = dict(response.headers)
         context.status_code = response.status_code
+        context.reason = reason_phrase
         return bytes(response.data)

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -358,7 +358,7 @@ def _requests_mock_callback(
         # requests-mock exposes headers as ``dict[str, str]``, so its callback
         # context cannot represent repeated fields.
         # ``response.status`` is the full WSGI status line, so preserve its
-        # reason phrase through requests-mock's callback context.
+        # reason phrase through the requests-mock callback context.
         _, _, reason_phrase = response.status.partition(" ")
         context.headers = dict(response.headers)
         context.status_code = response.status_code

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -362,6 +362,69 @@ def test_route_with_json(mock_ctx: _MockCtxType) -> None:
 
 
 @_MOCK_CTX_MARKER
+def test_custom_reason_phrase(mock_ctx: _MockCtxType) -> None:
+    """A custom HTTP reason phrase is preserved where the back end allows
+    it.
+
+    Only ``requests_mock`` exposes an API to set the reason phrase:
+
+    * ``responses`` derives the reason from a status-code map, so an unknown
+      code has no reason.
+    * ``respx`` reads the phrase via the ``httpx`` WSGI transport, which drops
+      it, so the reason phrase is empty.
+    * HTTPretty crashes on unknown status codes (tracked in #1844), so it is
+      not exercised here.
+    """
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/")
+    def _() -> Response:
+        """Return a response with a custom reason phrase."""
+        return Response(response="Hello", status="299 Custom Reason")
+
+    test_client = app.test_client()
+    response = test_client.get("/")
+
+    expected_status_code = 299
+
+    assert response.status == "299 Custom Reason"
+    assert response.status_code == expected_status_code
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+
+        if mock_obj_to_add is httpretty:
+            pytest.skip(
+                reason="HTTPretty crashes on unknown status codes; see #1844."
+            )
+
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com",
+        )
+
+    assert mock_response.status_code == expected_status_code
+
+    if isinstance(mock_obj_to_add, (respx.MockRouter, respx.Router)):
+        assert isinstance(mock_response, httpx.Response)
+        assert mock_response.reason_phrase == ""
+    elif isinstance(
+        mock_obj_to_add, (requests_mock.Mocker, requests_mock.Adapter)
+    ):
+        assert isinstance(mock_response, requests.Response)
+        assert mock_response.reason == "Custom Reason"
+    else:
+        assert isinstance(mock_response, requests.Response)
+        assert mock_response.reason is None
+
+
+@_MOCK_CTX_MARKER
 def test_route_with_variable_no_type_given(mock_ctx: _MockCtxType) -> None:
     """A route with a variable works."""
     app = Flask(import_name=__name__, static_folder=None)


### PR DESCRIPTION
Closes #1843.

Flask/Werkzeug responses can carry a custom HTTP reason phrase, but the forwarding callbacks reduced the status to `response.status_code`, losing the phrase.

This forwards the reason phrase through the `requests_mock` callback via `context.reason`, the only back end whose API allows setting a custom reason. The other back ends cannot: `responses` and HTTPretty derive the reason from a status-code map, and respx's httpx WSGI transport drops the phrase. Those limitations are documented and asserted in the new `test_custom_reason_phrase` test (HTTPretty is skipped due to the separate unknown-status crash in #1844).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to the requests_mock callback plus tests; no auth, data, or API surface changes beyond richer status metadata for one backend.
> 
> **Overview**
> Flask responses can use a **custom HTTP reason phrase** (e.g. `299 Custom Reason`), but the `requests_mock` forwarding path only set `context.status_code`, so the phrase was lost on mocked `requests` responses.
> 
> **`_requests_mock_callback`** now parses the reason from Werkzeug’s full `response.status` line and assigns **`context.reason`**, which is the only supported mock back end for custom phrases. Other backends are unchanged: **`responses`** has no reason for unknown codes, **respx** still gets an empty phrase via httpx’s WSGI transport, and **HTTPretty** remains skipped in the new test because of the separate unknown-status crash (#1844).
> 
> A parametrized **`test_custom_reason_phrase`** locks in those expectations plus the `requests_mock` fix; the changelog notes the behavior for #1843.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12364fec9ffe70c15630140627da80fd2400eaee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->