### PR TITLE
fix: Respect host-constrained Flask rules when registering URLs

### DIFF
--- a/newsfragments/1846.change.rst
+++ b/newsfragments/1846.change.rst
@@ -1,0 +1,1 @@
+Host-constrained Flask rules are now only registered against a ``base_url`` whose host matches the rule's host.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -50,6 +50,19 @@ _MockObjType = (
 )
 
 
+def _host_rule_matches_base_url(
+    *,
+    host_rule: str,
+    base_url_host: str | None,
+) -> bool:
+    """Return whether a Flask host rule applies to ``base_url_host``."""
+    if base_url_host is None:
+        return False
+    host_pattern = re.sub(pattern="<path:.+?>", repl=".+", string=host_rule)
+    host_pattern = re.sub(pattern="<.+?>", repl="[^.]+", string=host_pattern)
+    return re.fullmatch(pattern=host_pattern, string=base_url_host) is not None
+
+
 @dataclasses.dataclass(frozen=True)
 class _MockCallbacks:
     """Callbacks for each supported mock back end."""
@@ -167,7 +180,13 @@ def add_flask_app_to_mock(
         httpretty=httpretty_callback,
     )
 
+    base_url_host = urlsplit(url=base_url).hostname
     for rule in flask_app.url_map.iter_rules():
+        if rule.host is not None and not _host_rule_matches_base_url(
+            host_rule=rule.host,
+            base_url_host=base_url_host,
+        ):
+            continue
         # Build the URL pattern from the framework's parsed rule metadata.
         # Re-parsing ``rule.rule`` with a naive regex breaks on
         # converter arguments that contain a quoted ``>`` (e.g.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -52,14 +52,27 @@ _MockObjType = (
 
 def _host_rule_matches_base_url(
     *,
-    host_rule: str,
+    rule: "Rule",
     base_url_host: str | None,
 ) -> bool:
     """Return whether a Flask host rule applies to ``base_url_host``."""
     if base_url_host is None:
         return False
-    host_pattern = re.sub(pattern="<path:.+?>", repl=".+", string=host_rule)
-    host_pattern = re.sub(pattern="<.+?>", repl="[^.]+", string=host_pattern)
+
+    rule.compile()
+    host_parts: list[str] = []
+    rule_attributes: Any = vars(rule)
+    rule_trace = rule_attributes["_trace"]
+    rule_converters = rule_attributes["_converters"]
+    separator_index = rule_trace.index((False, "|"))
+    for is_dynamic, data in rule_trace[:separator_index]:
+        if is_dynamic:
+            converter = rule_converters[data]
+            host_parts.append(f"(?:{converter.regex})")
+        else:
+            host_parts.append(re.escape(pattern=data))
+
+    host_pattern = "".join(host_parts)
     return re.fullmatch(pattern=host_pattern, string=base_url_host) is not None
 
 
@@ -183,7 +196,7 @@ def add_flask_app_to_mock(
     base_url_host = urlsplit(url=base_url).hostname
     for rule in flask_app.url_map.iter_rules():
         if rule.host is not None and not _host_rule_matches_base_url(
-            host_rule=rule.host,
+            rule=rule,
             base_url_host=base_url_host,
         ):
             continue

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -26,10 +26,7 @@ from requests_mock.exceptions import NoMockAddress
 from respx.models import AllMockedAssertionError
 from werkzeug.routing import BaseConverter, Map
 
-from requests_mock_flask import (
-    _host_rule_matches_base_url,
-    add_flask_app_to_mock,
-)
+from requests_mock_flask import add_flask_app_to_mock
 
 # We use a high timeout to allow interactive debugging while requests are being
 # made.
@@ -54,11 +51,19 @@ _MOCK_CTXS: list[_MockCtxType] = [
 _MOCK_IDS = ["responses", "requests_mock", "httpretty", "respx"]
 
 
-def test_host_rule_does_not_match_missing_base_url_host() -> None:
+def test_host_rule_does_not_match_hostless_base_url() -> None:
     """A host-constrained rule cannot match a URL without a host."""
-    assert not _host_rule_matches_base_url(
-        host_rule="example.com",
-        base_url_host=None,
+    app = Flask(import_name=__name__, static_folder=None, host_matching=True)
+
+    @app.route("/", host="example.com")
+    def _() -> str:
+        """Return a simple message."""
+        return "matched"
+
+    add_flask_app_to_mock(
+        mock_obj=responses.RequestsMock(),
+        flask_app=app,
+        base_url="hostless",
     )
 
 

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1926,8 +1926,8 @@ def test_host_matching_rule_treats_dots_as_literals() -> None:
 
 
 @pytest.mark.parametrize(
-    ("base_url", "should_register"),
-    [
+    argnames=("base_url", "should_register"),
+    argvalues=[
         pytest.param("http://123.example.com", True, id="valid"),
         pytest.param("http://tenant.example.com", False, id="invalid"),
     ],
@@ -1943,7 +1943,7 @@ def test_host_matching_rule_respects_converter(
     @app.route(rule="/", host="<int:tenant>.example.com")
     def _(tenant: int) -> str:
         """Return the converted tenant."""
-        return str(tenant)
+        return f"{tenant}"
 
     direct_response = app.test_client().get(
         "/",

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -26,7 +26,10 @@ from requests_mock.exceptions import NoMockAddress
 from respx.models import AllMockedAssertionError
 from werkzeug.routing import BaseConverter, Map
 
-from requests_mock_flask import add_flask_app_to_mock
+from requests_mock_flask import (
+    _host_rule_matches_base_url,
+    add_flask_app_to_mock,
+)
 
 # We use a high timeout to allow interactive debugging while requests are being
 # made.
@@ -49,6 +52,14 @@ _MOCK_CTXS: list[_MockCtxType] = [
 ]
 
 _MOCK_IDS = ["responses", "requests_mock", "httpretty", "respx"]
+
+
+def test_host_rule_does_not_match_missing_base_url_host() -> None:
+    """A host-constrained rule cannot match a URL without a host."""
+    assert not _host_rule_matches_base_url(
+        host_rule="example.com",
+        base_url_host=None,
+    )
 
 _MOCK_CTX_MARKER = pytest.mark.parametrize(
     argnames="mock_ctx",

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1912,6 +1912,49 @@ def _host_matching_app() -> Flask:
     return app
 
 
+def test_host_matching_rule_treats_dots_as_literals() -> None:
+    """Dots in a host rule do not match arbitrary characters."""
+    mock_obj = responses.RequestsMock()
+
+    add_flask_app_to_mock(
+        mock_obj=mock_obj,
+        flask_app=_host_matching_app(),
+        base_url="http://apiXexampleYcom",
+    )
+
+    assert not mock_obj.registered()
+
+
+@pytest.mark.parametrize(
+    ("base_url", "should_register"),
+    [
+        pytest.param("http://123.example.com", True, id="valid"),
+        pytest.param("http://tenant.example.com", False, id="invalid"),
+    ],
+)
+def test_host_matching_rule_respects_converter(
+    base_url: str,
+    *,
+    should_register: bool,
+) -> None:
+    """Dynamic host rules use their Werkzeug converter constraints."""
+    app = Flask(import_name=__name__, host_matching=True, static_folder=None)
+
+    @app.route(rule="/", host="<int:tenant>.example.com")
+    def _(tenant: int) -> str:
+        """Return the converted tenant."""
+        return str(tenant)
+
+    mock_obj = responses.RequestsMock()
+    add_flask_app_to_mock(
+        mock_obj=mock_obj,
+        flask_app=app,
+        base_url=base_url,
+    )
+
+    assert bool(mock_obj.registered()) is should_register
+
+
 @_MOCK_CTX_MARKER
 def test_host_matching_rule_not_registered_for_other_host(
     mock_ctx: _MockCtxType,

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1937,13 +1937,19 @@ def test_host_matching_rule_respects_converter(
     *,
     should_register: bool,
 ) -> None:
-    """Dynamic host rules use their Werkzeug converter constraints."""
+    """Dynamic host rules use their routing converter constraints."""
     app = Flask(import_name=__name__, host_matching=True, static_folder=None)
 
     @app.route(rule="/", host="<int:tenant>.example.com")
     def _(tenant: int) -> str:
         """Return the converted tenant."""
         return str(tenant)
+
+    direct_response = app.test_client().get(
+        "/",
+        base_url="http://123.example.com",
+    )
+    assert direct_response.text == "123"
 
     mock_obj = responses.RequestsMock()
     add_flask_app_to_mock(

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -55,10 +55,10 @@ def test_host_rule_does_not_match_hostless_base_url() -> None:
     """A host-constrained rule cannot match a URL without a host."""
     app = Flask(import_name=__name__, static_folder=None, host_matching=True)
 
-    @app.route("/", host="example.com")
+    @app.route(rule="/", host="example.com")
     def _() -> str:
         """Return a simple message."""
-        return "matched"
+        return "matched"  # pragma: no cover
 
     add_flask_app_to_mock(
         mock_obj=responses.RequestsMock(),

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1881,3 +1881,65 @@ def test_missing_trailing_slash_redirect(mock_ctx: _MockCtxType) -> None:
 
     direct_response = test_client.get("/folder/")
     assert direct_response.data == b"Hello, World!"
+
+
+def _host_matching_app() -> Flask:
+    """Create an app with one host-constrained route."""
+    app = Flask(import_name=__name__, host_matching=True, static_folder=None)
+
+    @app.route(rule="/", host="api.example.com")
+    def _() -> str:
+        """Return a simple message."""
+        return "Hello, World!"
+
+    return app
+
+
+@_MOCK_CTX_MARKER
+def test_host_matching_rule_not_registered_for_other_host(
+    mock_ctx: _MockCtxType,
+) -> None:
+    """A host-constrained rule is skipped for a different base URL host."""
+    app = _host_matching_app()
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://other.example.com",
+        )
+        expected_exceptions: tuple[type[Exception], ...] = (
+            AllMockedAssertionError,
+            requests.exceptions.ConnectionError,
+            NoMockAddress,
+            ValueError,
+        )
+        with pytest.raises(expected_exception=expected_exceptions):
+            _do_get(
+                mock_obj=mock_obj_to_add,
+                url="http://other.example.com/",
+            )
+
+
+@_MOCK_CTX_MARKER
+def test_host_matching_rule_registered_for_matching_host(
+    mock_ctx: _MockCtxType,
+) -> None:
+    """A host-constrained rule is registered for a matching base URL host."""
+    app = _host_matching_app()
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://api.example.com",
+        )
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://api.example.com/",
+        )
+
+    assert mock_response.status_code == HTTPStatus.OK
+    assert mock_response.text == "Hello, World!"

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1899,7 +1899,9 @@ def _host_matching_app() -> Flask:
 def test_host_matching_rule_not_registered_for_other_host(
     mock_ctx: _MockCtxType,
 ) -> None:
-    """A host-constrained rule is skipped for a different base URL host."""
+    """A host-constrained rule is skipped for a different base URL
+    host.
+    """
     app = _host_matching_app()
 
     with mock_ctx() as mock_obj:
@@ -1926,7 +1928,9 @@ def test_host_matching_rule_not_registered_for_other_host(
 def test_host_matching_rule_registered_for_matching_host(
     mock_ctx: _MockCtxType,
 ) -> None:
-    """A host-constrained rule is registered for a matching base URL host."""
+    """A host-constrained rule is registered for a matching base URL
+    host.
+    """
     app = _host_matching_app()
 
     with mock_ctx() as mock_obj:

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -61,6 +61,7 @@ def test_host_rule_does_not_match_missing_base_url_host() -> None:
         base_url_host=None,
     )
 
+
 _MOCK_CTX_MARKER = pytest.mark.parametrize(
     argnames="mock_ctx",
     argvalues=_MOCK_CTXS,


### PR DESCRIPTION
Closes #1846.

When a Flask app uses host matching (`Flask(host_matching=True)`), each URL rule is constrained to a specific host via `rule.host`. Previously `add_flask_app_to_mock` ignored the host and registered every rule's path against the supplied `base_url`, so a rule constrained to `api.example.com` was wrongly installed on any other host and turned unrelated traffic into Flask 404s.

The registration loop now skips any rule whose host does not match the `base_url` host, so the interception URL set reflects the same routing constraints Flask applies. Non-host-matching apps are unaffected. This is distinct from forwarding the incoming Host header (#1830).

Added focused tests covering both the unmatched and matching host cases, plus a news fragment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to mock URL registration with broad test coverage; no auth or production runtime impact.
> 
> **Overview**
> **Host-matching Flask apps** no longer register every route against whatever `base_url` you pass in. `add_flask_app_to_mock` now compares each rule’s `host` to the hostname from `base_url` and **skips** rules that don’t apply, so traffic on other hosts isn’t wrongly intercepted by another host’s routes.
> 
> Matching is done via new `_host_rule_matches_base_url`, which rebuilds the host pattern from Werkzeug’s compiled rule trace (literal segments escaped, dynamic parts use each converter’s regex). Hostless `base_url` values never match host-constrained rules. Apps without host rules are unchanged.
> 
> Tests cover mismatched/matching hosts across mock backends, literal dots in host names, and `<int:…>` host converters, plus a news fragment for #1846.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37fb25aeded1e7be713678c304461990b6a0bf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->