### PR TITLE
fix: Use Flask converter constraints when deciding which URLs to intercept

### DIFF
--- a/newsfragments/1845.change.rst
+++ b/newsfragments/1845.change.rst
@@ -1,1 +1,1 @@
-URL interception now honours Flask converter constraints, so requests that violate a route's converter (for example a non-integer where ``<int:...>`` is expected) are left unmatched instead of being forwarded.
+URL interception now honors Flask converter constraints, so requests that violate a route's converter (for example a non-integer where ``<int:...>`` is expected) are left unmatched instead of being forwarded.

--- a/newsfragments/1845.change.rst
+++ b/newsfragments/1845.change.rst
@@ -1,0 +1,1 @@
+URL interception now honours Flask converter constraints, so requests that violate a route's converter (for example a non-integer where ``<int:...>`` is expected) are left unmatched instead of being forwarded.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -221,8 +221,7 @@ def _rule_to_path_regex(rule: "Rule") -> str:
     for is_dynamic, data in rule_trace[separator_index + 1 :]:
         if is_dynamic:
             converter = rule_converters[data]
-            path_part = "[^/]+" if converter.part_isolating else ".+"
-            path_parts.append(path_part)
+            path_parts.append(converter.regex)
         else:
             path_parts.append(re.escape(pattern=data))
     return "".join(path_parts)

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -600,6 +600,7 @@ def test_route_with_custom_nonisolating_converter(
         regex = ".*?"
         part_isolating = False
 
+    assert not _EverythingConverter.part_isolating
     app.url_map.converters["everything"] = _EverythingConverter
 
     @app.route(rule="/files/<everything:value>")

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -56,6 +56,25 @@ _MOCK_CTX_MARKER = pytest.mark.parametrize(
     ids=_MOCK_IDS,
 )
 
+# Some tests cannot use httpretty because httpretty has a bug with
+# allow_net_connect=False when used with urllib3 2.3.0+.
+# See: https://github.com/gabrielfalcao/HTTPretty/issues/484
+_MOCK_CTXS_NO_HTTPRETTY: list[_MockCtxType] = [
+    ctx
+    for ctx, mock_id in zip(_MOCK_CTXS, _MOCK_IDS, strict=True)
+    if mock_id != "httpretty"
+]
+
+_MOCK_IDS_NO_HTTPRETTY = [
+    mock_id for mock_id in _MOCK_IDS if mock_id != "httpretty"
+]
+
+_MOCK_CTX_MARKER_NO_HTTPRETTY = pytest.mark.parametrize(
+    argnames="mock_ctx",
+    argvalues=_MOCK_CTXS_NO_HTTPRETTY,
+    ids=_MOCK_IDS_NO_HTTPRETTY,
+)
+
 
 def _get_mock_obj(mock_obj: _MockCtxManagerYieldType) -> _MockObjType:
     """Get the mock object, handling the None yield from httpretty."""
@@ -949,25 +968,24 @@ def test_multiple_http_verbs(mock_ctx: _MockCtxType) -> None:
     assert mock_post_response.text == expected_data.decode()
 
 
-@_MOCK_CTX_MARKER
+@_MOCK_CTX_MARKER_NO_HTTPRETTY
 def test_wrong_type_given(mock_ctx: _MockCtxType) -> None:
-    """A route with the wrong type given works."""
+    """A URL which violates a converter constraint is not intercepted.
+
+    Flask routing does not match ``/a`` against ``/<int:my_variable>``, so the
+    helper leaves the request unmatched instead of forwarding it and returning
+    Flask's 404.  A URL which satisfies the constraint is still intercepted.
+    """
     app = Flask(import_name=__name__, static_folder=None)
 
     @app.route(rule="/<int:my_variable>")
-    def _(_: int) -> str:
-        """Return an empty string."""
-        return ""  # pragma: no cover
+    def _(my_variable: int) -> str:
+        """Return a simple message which includes the route variable."""
+        return f"Hello: {my_variable}"
 
     test_client = app.test_client()
     response = test_client.get("/a")
-
-    expected_status_code = HTTPStatus.NOT_FOUND
-    expected_content_type = "text/html; charset=utf-8"
-
-    assert response.status_code == expected_status_code
-    assert response.headers["Content-Type"] == expected_content_type
-    assert b"not found on the server" in response.data
+    assert response.status_code == HTTPStatus.NOT_FOUND
 
     with mock_ctx() as mock_obj:
         mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
@@ -978,14 +996,24 @@ def test_wrong_type_given(mock_ctx: _MockCtxType) -> None:
             base_url="http://www.example.com",
         )
 
-        mock_response = _do_get(
+        expected_exceptions: tuple[type[Exception], ...] = (
+            AllMockedAssertionError,
+            requests.exceptions.ConnectionError,
+            NoMockAddress,
+        )
+        with pytest.raises(expected_exception=expected_exceptions):
+            _do_get(
+                mock_obj=mock_obj_to_add,
+                url="http://www.example.com/a",
+            )
+
+        valid_response = _do_get(
             mock_obj=mock_obj_to_add,
-            url="http://www.example.com/a",
+            url="http://www.example.com/123",
         )
 
-    assert mock_response.status_code == expected_status_code
-    assert mock_response.headers["Content-Type"] == expected_content_type
-    assert "not found on the server" in mock_response.text
+    assert valid_response.status_code == HTTPStatus.OK
+    assert valid_response.text == "Hello: 123"
 
 
 @_MOCK_CTX_MARKER
@@ -1563,26 +1591,6 @@ def test_multiple_variables_no_extra_segments(mock_ctx: _MockCtxType) -> None:
         )
         assert valid_response.status_code == HTTPStatus.OK
         assert valid_response.text == "Posts for: cranes/frasier"
-
-
-# This test cannot use httpretty because httpretty has a bug with
-# allow_net_connect=False when used with urllib3 2.3.0+.
-# See: https://github.com/gabrielfalcao/HTTPretty/issues/484
-_MOCK_CTXS_NO_HTTPRETTY: list[_MockCtxType] = [
-    ctx
-    for ctx, mock_id in zip(_MOCK_CTXS, _MOCK_IDS, strict=True)
-    if mock_id != "httpretty"
-]
-
-_MOCK_IDS_NO_HTTPRETTY = [
-    mock_id for mock_id in _MOCK_IDS if mock_id != "httpretty"
-]
-
-_MOCK_CTX_MARKER_NO_HTTPRETTY = pytest.mark.parametrize(
-    argnames="mock_ctx",
-    argvalues=_MOCK_CTXS_NO_HTTPRETTY,
-    ids=_MOCK_IDS_NO_HTTPRETTY,
-)
 
 
 @_MOCK_CTX_MARKER_NO_HTTPRETTY


### PR DESCRIPTION
Closes #1845.

`add_flask_app_to_mock` previously replaced every non-`path` converter with the generic `[^/]+`, so converter-constrained rules (e.g. `<int:order_id>`) intercepted URLs that Flask routing would reject (e.g. `not-an-integer`) and answered them with Flask's 404 instead of leaving the request available to another mock or passthrough.

The interception path regex is now built from Werkzeug rule/converter metadata (`rule._trace` + each converter's `.regex`), so the interception set matches Flask's routing set for built-in (`int`, `float`, `uuid`, `any`) and custom converters. This is independent of the anchoring (#1832) and part-isolation (#1837) concerns.

`test_wrong_type_given` is updated to assert `/orders`-style constraint violations are left unmatched (raising the backend's unmatched error) while a valid value is still intercepted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes which HTTP requests are intercepted across all mock backends—a behavioral breaking fix for tests that relied on the old loose matching; scope is limited to regex construction in `_rule_to_path_regex`.
> 
> **Overview**
> **Mock registration now aligns with Flask routing for typed path segments.** `_rule_to_path_regex` builds dynamic segments from each Werkzeug converter’s `regex` instead of generic `[^/]+` / `.+`, so URLs that Flask would not match (e.g. `/a` on `/<int:my_variable>`) are **not** intercepted and can fall through to other mocks or real networking.
> 
> `test_wrong_type_given` is rewritten to expect an unmatched-request error for invalid values while still forwarding valid ones (e.g. `/123`). The shared `_MOCK_CTX_MARKER_NO_HTTPRETTY` helper is hoisted earlier for reuse, and that marker is applied to the converter test to skip HTTPretty (urllib3 2.3+ issue). A small assertion was added in the custom non-isolating converter test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 624d21779270ecb095a4e09361876916e132f745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->