### PR TITLE
fix: Honor part_isolating=False for custom Flask converters

### DIFF
--- a/newsfragments/1837.change.rst
+++ b/newsfragments/1837.change.rst
@@ -1,0 +1,1 @@
+Custom Werkzeug converters that set ``part_isolating = False`` now correctly match values containing slashes.

--- a/newsfragments/1837.change.rst
+++ b/newsfragments/1837.change.rst
@@ -1,1 +1,1 @@
-Custom Werkzeug converters that set ``part_isolating = False`` now correctly match values containing slashes.
+Custom framework converters that set ``part_isolating = False`` now correctly match values containing slashes.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -14,7 +14,6 @@ import responses
 import respx
 import werkzeug
 from urllib3 import HTTPHeaderDict
-from werkzeug.routing.converters import PathConverter
 
 if TYPE_CHECKING:
     import flask
@@ -218,9 +217,7 @@ def _rule_to_path_regex(rule: "Rule") -> str:
     for is_dynamic, data in rule_trace[separator_index + 1 :]:
         if is_dynamic:
             converter = rule_converters[data]
-            path_part = ".+"
-            if not isinstance(converter, PathConverter):
-                path_part = "[^/]+"
+            path_part = "[^/]+" if converter.part_isolating else ".+"
             path_parts.append(path_part)
         else:
             path_parts.append(re.escape(pattern=data))

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -562,6 +562,42 @@ def test_route_with_path_variable_with_slash(mock_ctx: _MockCtxType) -> None:
 
 
 @_MOCK_CTX_MARKER
+def test_route_with_custom_nonisolating_converter(
+    mock_ctx: _MockCtxType,
+) -> None:
+    """A custom non-isolating converter can span path segments."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    class _EverythingConverter(werkzeug.routing.BaseConverter):
+        """Match values containing slashes."""
+
+        regex = ".*?"
+        part_isolating = False
+
+    app.url_map.converters["everything"] = _EverythingConverter
+
+    @app.route(rule="/files/<everything:value>")
+    def _(value: str) -> str:
+        """Return the converted value."""
+        return value
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com/files/foo/bar",
+        )
+
+    assert mock_response.status_code == HTTPStatus.OK
+    assert mock_response.text == "foo/bar"
+
+
+@_MOCK_CTX_MARKER
 def test_route_with_uuid_variable(mock_ctx: _MockCtxType) -> None:
     """A route with a uuid variable works."""
     app = Flask(import_name=__name__, static_folder=None)

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -568,7 +568,7 @@ def test_route_with_custom_nonisolating_converter(
     """A custom non-isolating converter can span path segments."""
     app = Flask(import_name=__name__, static_folder=None)
 
-    class _EverythingConverter(werkzeug.routing.BaseConverter):
+    class _EverythingConverter(BaseConverter):
         """Match values containing slashes."""
 
         regex = ".*?"


### PR DESCRIPTION
Closes #1837.

`add_flask_app_to_mock` decided slash-spanning matching purely from the literal `<path:...>` text, so a custom Werkzeug converter with `part_isolating = False` was wrongly rendered as `[^/]+` and HTTPretty rejected valid requests to it.

This inspects each rule's converter objects (`rule._converters`) and emits `.+` for any non-part-isolating converter (built-in `path` or custom), keeping `[^/]+` for the rest. Adds a focused test with a custom `part_isolating = False` converter matching a value containing `/`, run across all four backends, plus a news fragment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to route-to-regex mapping with new regression tests; behavior for standard part-isolating converters is unchanged.
> 
> **Overview**
> Fixes mock URL registration for Flask routes that use **custom Werkzeug converters** with `part_isolating = False`. Those routes were previously turned into single-segment patterns (`[^/]+`), so URLs with slashes in the captured value never matched and never reached the app.
> 
> `_rule_to_path_regex` now chooses `.+` vs `[^/]+` from each rule’s converter via **`part_isolating`**, same as built-in `path`, instead of treating only `PathConverter` as slash-spanning. The unused `PathConverter` import is dropped. A parametrized test covers a custom `everything` converter across all mock backends, plus a news fragment for #1837.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d255499bf3f343677de3cbc97875a958d9fd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->