### PR TITLE
fix: Support iterable streaming request bodies with requests backends

### DIFF
--- a/newsfragments/1842.change.rst
+++ b/newsfragments/1842.change.rst
@@ -1,0 +1,1 @@
+Support iterable streaming request bodies with the ``responses`` and ``requests-mock`` backends.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -4,7 +4,7 @@ import dataclasses
 import re
 from collections.abc import Callable, Iterable
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, BinaryIO, TypeGuard
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import httpretty
@@ -32,18 +32,37 @@ def _without_transfer_encoding(
     ]
 
 
-def _normalize_body(
-    body: Any,
-) -> Any:
+def _is_binary_io(body: object) -> TypeGuard[BinaryIO]:
+    """Return whether ``body`` provides a binary ``read`` method."""
+    return hasattr(body, "read")
+
+
+def _is_body_iterable(
+    body: object,
+) -> TypeGuard[Iterable[object]]:
+    """Return whether ``body`` is an iterable streaming body."""
+    return isinstance(body, Iterable)
+
+
+def _normalize_body(body: object) -> str | bytes | BinaryIO | None:
     """Convert streaming request bodies to bytes for the WSGI app."""
     if body is None or isinstance(body, str | bytes):
         return body
-    if not isinstance(body, Iterable):
+    if _is_binary_io(body=body):
         return body
-    return b"".join(
-        part.encode() if isinstance(part, str) else part
-        for part in cast("Iterable[str | bytes]", body)
-    )
+    if _is_body_iterable(body=body):
+        encoded_parts: list[bytes] = []
+        for part in body:
+            if isinstance(part, str):
+                encoded_parts.append(part.encode())
+            elif isinstance(part, bytes):
+                encoded_parts.append(part)
+            else:
+                msg = "Streaming body chunks must be strings or bytes."
+                raise TypeError(msg)
+        return b"".join(encoded_parts)
+    msg = "Request body must be readable or iterable."
+    raise TypeError(msg)
 
 
 # Known HTTP methods to register for every route URL. We register all of

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -35,7 +35,7 @@ def _without_transfer_encoding(
 def _normalize_body(
     body: str | bytes | Iterable[str | bytes] | None,
 ) -> str | bytes | None:
-    """Convert streaming request bodies to bytes for Werkzeug."""
+    """Convert streaming request bodies to bytes for the WSGI app."""
     if body is None or isinstance(body, str | bytes):
         return body
     return b"".join(

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -4,7 +4,7 @@ import dataclasses
 import re
 from collections.abc import Callable, Iterable
 from types import ModuleType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import httpretty
@@ -33,13 +33,16 @@ def _without_transfer_encoding(
 
 
 def _normalize_body(
-    body: str | bytes | Iterable[str | bytes] | None,
-) -> str | bytes | None:
+    body: Any,
+) -> Any:
     """Convert streaming request bodies to bytes for the WSGI app."""
     if body is None or isinstance(body, str | bytes):
         return body
+    if not isinstance(body, Iterable):
+        return body
     return b"".join(
-        part.encode() if isinstance(part, str) else part for part in body
+        part.encode() if isinstance(part, str) else part
+        for part in cast("Iterable[str | bytes]", body)
     )
 
 

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from types import ModuleType
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlsplit, urlunsplit
@@ -19,6 +19,18 @@ if TYPE_CHECKING:
     import flask
     import requests
     from werkzeug.routing import Rule
+
+
+def _without_transfer_encoding(headers: Iterable[tuple[str, str]]) -> list[tuple[str, str]]:
+    """Return headers excluding ``Transfer-Encoding``."""
+    return [(key, value) for key, value in headers if key.lower() != "transfer-encoding"]
+
+
+def _normalize_body(body: str | bytes | Iterable[str | bytes] | None) -> str | bytes | None:
+    """Convert streaming request bodies to bytes for Werkzeug."""
+    if body is None or isinstance(body, str | bytes):
+        return body
+    return b"".join(part.encode() if isinstance(part, str) else part for part in body)
 
 
 # Known HTTP methods to register for every route URL. We register all of
@@ -307,14 +319,14 @@ def _responses_callback(
     if "Content-Length" in request.headers:
         environ_overrides["CONTENT_LENGTH"] = request.headers["Content-Length"]
 
-    headers_dict = dict(request.headers).items()
+    headers_dict = _without_transfer_encoding(headers=dict(request.headers).items())
     split_url = urlsplit(url=str(object=request.url))
     base_url = f"{split_url.scheme}://{split_url.netloc}/"
     environ_builder = werkzeug.test.EnvironBuilder(
         path=request.path_url,
         base_url=base_url,
         method=str(object=request.method),
-        data=request.body,
+        data=_normalize_body(body=request.body),
         headers=headers_dict,
         environ_overrides=environ_overrides,
     )
@@ -415,8 +427,8 @@ def _requests_mock_callback(
         path=request.path_url,
         base_url=base_url,
         method=request.method,
-        headers=list(request.headers.items()),
-        data=request.body,
+        headers=_without_transfer_encoding(headers=request.headers.items()),
+        data=_normalize_body(body=request.body),
         environ_overrides=environ_overrides,
     )
     with test_client.open(environ_builder.get_request()) as response:

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -88,7 +88,7 @@ _MockObjType = (
 
 def _host_rule_matches_base_url(
     *,
-    rule: "Rule",
+    rule: Rule,
     base_url_host: str | None,
 ) -> bool:
     """Return whether a Flask host rule applies to ``base_url_host``."""

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -1,5 +1,7 @@
 """Package for ``requests_mock_flask``."""
 
+from __future__ import annotations
+
 import dataclasses
 import re
 from collections.abc import Callable, Iterable
@@ -20,6 +22,8 @@ if TYPE_CHECKING:
     import requests
     from werkzeug.routing import Rule
 
+    type _RequestBody = str | bytes | Iterable[str | bytes] | BinaryIO | None
+
 
 def _without_transfer_encoding(
     headers: Iterable[tuple[str, str]],
@@ -33,36 +37,21 @@ def _without_transfer_encoding(
 
 
 def _is_binary_io(body: object) -> TypeGuard[BinaryIO]:
-    """Return whether ``body`` provides a binary ``read`` method."""
-    return hasattr(body, "read")
+    """Return whether the body provides a file-like ``read`` method."""
+    return any("read" in vars(cls) for cls in type(body).mro())
 
 
-def _is_body_iterable(
-    body: object,
-) -> TypeGuard[Iterable[object]]:
-    """Return whether ``body`` is an iterable streaming body."""
-    return isinstance(body, Iterable)
-
-
-def _normalize_body(body: object) -> str | bytes | BinaryIO | None:
+def _normalize_body(
+    body: _RequestBody,
+) -> str | bytes | BinaryIO | None:
     """Convert streaming request bodies to bytes for the WSGI app."""
     if body is None or isinstance(body, str | bytes):
         return body
     if _is_binary_io(body=body):
         return body
-    if _is_body_iterable(body=body):
-        encoded_parts: list[bytes] = []
-        for part in body:
-            if isinstance(part, str):
-                encoded_parts.append(part.encode())
-            elif isinstance(part, bytes):
-                encoded_parts.append(part)
-            else:
-                msg = "Streaming body chunks must be strings or bytes."
-                raise TypeError(msg)
-        return b"".join(encoded_parts)
-    msg = "Request body must be readable or iterable."
-    raise TypeError(msg)
+    return b"".join(
+        part.encode() if isinstance(part, str) else part for part in body
+    )
 
 
 # Known HTTP methods to register for every route URL. We register all of
@@ -206,7 +195,7 @@ def _normalize_base_url(*, base_url: str) -> str:
 
 def add_flask_app_to_mock(
     mock_obj: _MockObjType,
-    flask_app: "flask.Flask",
+    flask_app: flask.Flask,
     base_url: str,
 ) -> None:
     """
@@ -224,14 +213,14 @@ def add_flask_app_to_mock(
         return transport.handle_request(request=request)
 
     def responses_callback(
-        request: "requests.PreparedRequest",
+        request: requests.PreparedRequest,
     ) -> tuple[int, HTTPHeaderDict, bytes]:
         """Callback for responses."""
         return _responses_callback(request=request, flask_app=flask_app)
 
     def requests_mock_callback(
-        request: "requests_mock.Request",
-        context: "requests_mock.Context",
+        request: requests_mock.Request,
+        context: requests_mock.Context,
     ) -> bytes:
         """Callback for requests_mock."""
         return _requests_mock_callback(
@@ -241,7 +230,7 @@ def add_flask_app_to_mock(
         )
 
     def httpretty_callback(
-        request: "httpretty.core.HTTPrettyRequest",
+        request: httpretty.core.HTTPrettyRequest,
         uri: str,
         headers: dict[str, Any],
     ) -> tuple[int, HTTPHeaderDict, bytes]:
@@ -308,7 +297,7 @@ def add_flask_app_to_mock(
                 )
 
 
-def _rule_to_path_regex(rule: "Rule") -> str:
+def _rule_to_path_regex(rule: Rule) -> str:
     """Return a regex that matches the path part of a Flask routing
     rule.
     """
@@ -328,8 +317,8 @@ def _rule_to_path_regex(rule: "Rule") -> str:
 
 
 def _responses_callback(
-    request: "requests.PreparedRequest",
-    flask_app: "flask.Flask",
+    request: requests.PreparedRequest,
+    flask_app: flask.Flask,
 ) -> tuple[int, HTTPHeaderDict, bytes]:
     """Given a request to the flask app, send an equivalent request to an
     in
@@ -374,10 +363,10 @@ def _responses_callback(
 
 
 def _httpretty_callback(
-    request: "httpretty.core.HTTPrettyRequest",
+    request: httpretty.core.HTTPrettyRequest,
     uri: str,
     headers: dict[str, Any],
-    flask_app: "flask.Flask",
+    flask_app: flask.Flask,
 ) -> tuple[int, HTTPHeaderDict, bytes]:
     """Given a request to the Flask app, send an equivalent request to an
     in
@@ -430,9 +419,9 @@ def _httpretty_callback(
 
 
 def _requests_mock_callback(
-    request: "requests_mock.Request",
-    context: "requests_mock.Context",
-    flask_app: "flask.Flask",
+    request: requests_mock.Request,
+    context: requests_mock.Context,
+    flask_app: flask.Flask,
 ) -> bytes:
     """Given a request to the Flask app, send an equivalent request to an
     in

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -21,16 +21,26 @@ if TYPE_CHECKING:
     from werkzeug.routing import Rule
 
 
-def _without_transfer_encoding(headers: Iterable[tuple[str, str]]) -> list[tuple[str, str]]:
+def _without_transfer_encoding(
+    headers: Iterable[tuple[str, str]],
+) -> list[tuple[str, str]]:
     """Return headers excluding ``Transfer-Encoding``."""
-    return [(key, value) for key, value in headers if key.lower() != "transfer-encoding"]
+    return [
+        (key, value)
+        for key, value in headers
+        if key.lower() != "transfer-encoding"
+    ]
 
 
-def _normalize_body(body: str | bytes | Iterable[str | bytes] | None) -> str | bytes | None:
+def _normalize_body(
+    body: str | bytes | Iterable[str | bytes] | None,
+) -> str | bytes | None:
     """Convert streaming request bodies to bytes for Werkzeug."""
     if body is None or isinstance(body, str | bytes):
         return body
-    return b"".join(part.encode() if isinstance(part, str) else part for part in body)
+    return b"".join(
+        part.encode() if isinstance(part, str) else part for part in body
+    )
 
 
 # Known HTTP methods to register for every route URL. We register all of
@@ -319,7 +329,9 @@ def _responses_callback(
     if "Content-Length" in request.headers:
         environ_overrides["CONTENT_LENGTH"] = request.headers["Content-Length"]
 
-    headers_dict = _without_transfer_encoding(headers=dict(request.headers).items())
+    headers_dict = _without_transfer_encoding(
+        headers=dict(request.headers).items(),
+    )
     split_url = urlsplit(url=str(object=request.url))
     base_url = f"{split_url.scheme}://{split_url.netloc}/"
     environ_builder = werkzeug.test.EnvironBuilder(

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import dataclasses
 import re
-from collections.abc import Callable, Iterable
+from operator import methodcaller
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, BinaryIO, TypeGuard
+from typing import TYPE_CHECKING, Any, BinaryIO
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import httpretty
@@ -18,6 +18,8 @@ import werkzeug
 from urllib3 import HTTPHeaderDict
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     import flask
     import requests
     from werkzeug.routing import Rule
@@ -36,19 +38,20 @@ def _without_transfer_encoding(
     ]
 
 
-def _is_binary_io(body: object) -> TypeGuard[BinaryIO]:
+def _is_binary_io(body: object) -> bool:
     """Return whether the body provides a file-like ``read`` method."""
     return any("read" in vars(cls) for cls in type(body).mro())
 
 
 def _normalize_body(
     body: _RequestBody,
-) -> str | bytes | BinaryIO | None:
+) -> str | bytes | None:
     """Convert streaming request bodies to bytes for the WSGI app."""
     if body is None or isinstance(body, str | bytes):
         return body
     if _is_binary_io(body=body):
-        return body
+        body_bytes: bytes = methodcaller("read")(body)
+        return body_bytes
     return b"".join(
         part.encode() if isinstance(part, str) else part for part in body
     )

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -24,7 +24,15 @@ if TYPE_CHECKING:
     import requests
     from werkzeug.routing import Rule
 
-    type _RequestBody = str | bytes | Iterable[str | bytes] | BinaryIO | None
+    type _RequestBody = (
+        str
+        | bytes
+        | bytearray
+        | memoryview
+        | Iterable[str | bytes]
+        | BinaryIO
+        | None
+    )
 
 
 def _without_transfer_encoding(
@@ -49,6 +57,8 @@ def _normalize_body(
     """Convert streaming request bodies to bytes for the WSGI app."""
     if body is None or isinstance(body, str | bytes):
         return body
+    if isinstance(body, bytearray | memoryview):
+        return bytes(body)
     if _is_binary_io(body=body):
         body_bytes: bytes = methodcaller("read")(body)
         return body_bytes

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager
 from functools import partial
 from http import HTTPStatus
+from io import BytesIO
 from types import ModuleType
 from typing import Any, Final
 
@@ -1298,6 +1299,30 @@ def test_iterable_streaming_request_body(mock_ctx: _MockCtxType) -> None:
     assert mock_response.status_code == expected_status_code
     if delivers_body:
         assert mock_response.text == expected_data.decode()
+
+
+def test_file_like_request_body() -> None:
+    """A readable, non-iterable request body remains supported."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.post("/")
+    def _() -> bytes:
+        """Echo the request body."""
+        return request.get_data()
+
+    with requests_mock.Mocker() as mock_obj:
+        add_flask_app_to_mock(
+            mock_obj=mock_obj,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+        response = requests.post(
+            "http://www.example.com",
+            data=BytesIO(b"body"),
+            timeout=_TIMEOUT_SECONDS,
+        )
+
+    assert response.content == b"body"
 
 
 @_MOCK_CTX_MARKER

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1245,6 +1245,62 @@ def test_request_needs_data(mock_ctx: _MockCtxType) -> None:
 
 
 @_MOCK_CTX_MARKER
+def test_iterable_streaming_request_body(mock_ctx: _MockCtxType) -> None:
+    """Iterable (chunked/streaming) request bodies do not crash the
+    callback.
+
+    With the ``responses`` and ``requests-mock`` backends the iterable is
+    consumed into raw bytes and delivered to Flask. The other backends leave
+    the body chunk-framed or unread, but must at least not error.
+    """
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/", methods=["POST"])
+    def _() -> str:
+        """Echo the raw request body."""
+        return request.get_data(as_text=True)
+
+    expected_status_code = HTTPStatus.OK
+    expected_data = b"abcdef"
+
+    def chunks() -> Iterator[bytes]:
+        """Yield the request body in chunks."""
+        yield b"abc"
+        yield b"def"
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+
+        mock_response: requests.Response | httpx.Response
+        delivers_body = isinstance(
+            mock_obj_to_add,
+            (responses.RequestsMock, requests_mock.Mocker),
+        )
+        if isinstance(mock_obj_to_add, (respx.MockRouter, respx.Router)):
+            mock_response = httpx.post(
+                url="http://www.example.com",
+                content=chunks(),
+                timeout=_TIMEOUT_SECONDS,
+            )
+        else:
+            mock_response = requests.post(
+                url="http://www.example.com",
+                data=chunks(),
+                timeout=_TIMEOUT_SECONDS,
+            )
+
+    assert mock_response.status_code == expected_status_code
+    if delivers_body:
+        assert mock_response.text == expected_data.decode()
+
+
+@_MOCK_CTX_MARKER
 def test_multiple_functions_same_path_different_type(
     mock_ctx: _MockCtxType,
 ) -> None:

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1308,7 +1308,7 @@ def test_file_like_request_body() -> None:
     normalize_body: Callable[[object], object] = vars(requests_mock_flask)[
         "_normalize_body"
     ]
-    assert normalize_body(body) is body
+    assert normalize_body(body) == b"body"
 
 
 @_MOCK_CTX_MARKER

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -10,7 +10,6 @@ from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager
 from functools import partial
 from http import HTTPStatus
-from io import BytesIO
 from types import ModuleType
 from typing import Any, Final
 
@@ -1305,7 +1304,19 @@ def test_file_like_request_body() -> None:
     """A readable, non-iterable request body remains supported."""
     app = Flask(import_name=__name__, static_folder=None)
 
-    @app.post("/")
+    class ReadableBody:
+        """A file-like body without an iterator."""
+
+        consumed = False
+
+        def read(self, _size: int = -1) -> bytes:
+            """Return the body once."""
+            if self.consumed:
+                return b""
+            self.consumed = True
+            return b"body"
+
+    @app.post(rule="/")
     def _() -> bytes:
         """Echo the request body."""
         return request.get_data()
@@ -1317,8 +1328,8 @@ def test_file_like_request_body() -> None:
             base_url="http://www.example.com",
         )
         response = requests.post(
-            "http://www.example.com",
-            data=BytesIO(b"body"),
+            url="http://www.example.com",
+            data=ReadableBody(),
             timeout=_TIMEOUT_SECONDS,
         )
 

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -10,9 +10,9 @@ from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager
 from functools import partial
 from http import HTTPStatus
+from io import BytesIO
 from types import ModuleType
 from typing import Any, Final
-from unittest.mock import Mock
 
 import httpretty
 import httpx
@@ -1304,7 +1304,7 @@ def test_iterable_streaming_request_body(mock_ctx: _MockCtxType) -> None:
 
 def test_file_like_request_body() -> None:
     """A readable, non-iterable request body remains supported."""
-    body = Mock()
+    body = BytesIO(initial_bytes=b"body")
     normalize_body: Callable[[object], object] = vars(requests_mock_flask)[
         "_normalize_body"
     ]

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -27,7 +27,6 @@ from requests_mock.exceptions import NoMockAddress
 from respx.models import AllMockedAssertionError
 from werkzeug.routing import BaseConverter, Map
 
-import requests_mock_flask
 from requests_mock_flask import add_flask_app_to_mock
 
 # We use a high timeout to allow interactive debugging while requests are being
@@ -1304,11 +1303,31 @@ def test_iterable_streaming_request_body(mock_ctx: _MockCtxType) -> None:
 
 def test_file_like_request_body() -> None:
     """A readable, non-iterable request body remains supported."""
-    body = BytesIO(initial_bytes=b"body")
-    normalize_body: Callable[[object], object] = vars(requests_mock_flask)[
-        "_normalize_body"
-    ]
-    assert normalize_body(body) == b"body"
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/", methods=["POST"])
+    def _() -> bytes:
+        """Echo the request body."""
+        return request.get_data()
+
+    prepared_request = requests.Request(
+        method="POST",
+        url="http://www.example.com",
+        data=BytesIO(initial_bytes=b"body"),
+    ).prepare()
+
+    with requests_mock.Mocker() as mock_obj:
+        add_flask_app_to_mock(
+            mock_obj=mock_obj,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+        response = requests.Session().send(
+            request=prepared_request,
+            timeout=_TIMEOUT_SECONDS,
+        )
+
+    assert response.content == b"body"
 
 
 @_MOCK_CTX_MARKER

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -1301,8 +1301,21 @@ def test_iterable_streaming_request_body(mock_ctx: _MockCtxType) -> None:
         assert mock_response.text == expected_data.decode()
 
 
-def test_file_like_request_body() -> None:
-    """A readable, non-iterable request body remains supported."""
+@pytest.mark.parametrize(
+    argnames="body",
+    argvalues=[
+        pytest.param(BytesIO(initial_bytes=b"body"), id="file-like"),
+        pytest.param(bytearray(b"body"), id="bytearray"),
+        pytest.param(
+            BytesIO(initial_bytes=b"body").getbuffer(),
+            id="memoryview",
+        ),
+    ],
+)
+def test_non_streaming_request_body(
+    body: BytesIO | bytearray | memoryview,
+) -> None:
+    """A file-like or buffer request body is delivered to Flask."""
     app = Flask(import_name=__name__, static_folder=None)
 
     @app.route(rule="/", methods=["POST"])
@@ -1313,7 +1326,7 @@ def test_file_like_request_body() -> None:
     prepared_request = requests.Request(
         method="POST",
         url="http://www.example.com",
-        data=BytesIO(initial_bytes=b"body"),
+        data=body,
     ).prepare()
 
     with requests_mock.Mocker() as mock_obj:

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -12,6 +12,7 @@ from functools import partial
 from http import HTTPStatus
 from types import ModuleType
 from typing import Any, Final
+from unittest.mock import Mock
 
 import httpretty
 import httpx
@@ -26,6 +27,7 @@ from requests_mock.exceptions import NoMockAddress
 from respx.models import AllMockedAssertionError
 from werkzeug.routing import BaseConverter, Map
 
+import requests_mock_flask
 from requests_mock_flask import add_flask_app_to_mock
 
 # We use a high timeout to allow interactive debugging while requests are being
@@ -1302,38 +1304,11 @@ def test_iterable_streaming_request_body(mock_ctx: _MockCtxType) -> None:
 
 def test_file_like_request_body() -> None:
     """A readable, non-iterable request body remains supported."""
-    app = Flask(import_name=__name__, static_folder=None)
-
-    class ReadableBody:
-        """A file-like body without an iterator."""
-
-        consumed = False
-
-        def read(self, _size: int = -1) -> bytes:
-            """Return the body once."""
-            if self.consumed:
-                return b""
-            self.consumed = True
-            return b"body"
-
-    @app.post(rule="/")
-    def _() -> bytes:
-        """Echo the request body."""
-        return request.get_data()
-
-    with requests_mock.Mocker() as mock_obj:
-        add_flask_app_to_mock(
-            mock_obj=mock_obj,
-            flask_app=app,
-            base_url="http://www.example.com",
-        )
-        response = requests.post(
-            url="http://www.example.com",
-            data=ReadableBody(),
-            timeout=_TIMEOUT_SECONDS,
-        )
-
-    assert response.content == b"body"
+    body = Mock()
+    normalize_body: Callable[[object], object] = vars(requests_mock_flask)[
+        "_normalize_body"
+    ]
+    assert normalize_body(body) is body
 
 
 @_MOCK_CTX_MARKER


### PR DESCRIPTION
Closes #1842.

`requests` supports iterable request bodies for streaming/chunked uploads. With the `responses` and `requests-mock` backends, `request.body` remains a generator, which the callbacks passed straight to Werkzeug's `EnvironBuilder(data=...)`. That treats the generator as form data and calls `.items()`, raising `AttributeError` before Flask receives the request.

This consumes an iterable/generator body into raw bytes before building the environ, and drops the leftover `Transfer-Encoding: chunked` header (the consumed body has a known `Content-Length`, and leaving the chunked header would make Werkzeug read an empty body). Non-iterable bodies (bytes/str/None) are passed through unchanged.

Adds a focused test using a generator body across all four backends: it asserts 200 everywhere (no crash) and that the decoded bytes reach Flask for the `responses` and `requests-mock` backends.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to request-body normalization in test mock callbacks; bytes/str/None behavior is unchanged and coverage is added.
> 
> **Overview**
> Fixes crashes when **`responses`** or **`requests-mock`** forward POSTs whose `request.body` is an **iterable/generator** (streaming/chunked uploads). Those bodies are now **materialized** via `_normalize_body` (iterables joined to bytes; `bytearray`/`memoryview`/file-like `read()` supported) before Werkzeug's `EnvironBuilder` runs, instead of being mis-handled as form data.
> 
> For the same paths, **`Transfer-Encoding: chunked`** is stripped with `_without_transfer_encoding` so Werkzeug uses the known body length rather than treating the request as still chunked.
> 
> Adds tests: iterable bodies across all mock backends (200 everywhere; full body echoed for `responses`/`requests-mock`), plus `requests-mock` coverage for file-like and buffer bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72dba4998c863d6a97a7dbe4acfef1a48ba7fc22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->