### PR TITLE
fix: Prevent HTTPretty crashes for nonstandard Flask status codes

### DIFF
--- a/newsfragments/1844.change.rst
+++ b/newsfragments/1844.change.rst
@@ -1,0 +1,1 @@
+Prevent HTTPretty from crashing on nonstandard Flask status codes.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -315,7 +315,8 @@ def _httpretty_callback(
         environ_overrides=environ_overrides,
     )
     with test_client.open(environ_builder.get_request()) as response:
-        statuses: dict[int, str] = getattr(httpretty, "http").STATUSES
+        http_module: Any = vars(httpretty)["http"]
+        statuses: dict[int, str] = http_module.STATUSES
         if response.status_code not in statuses:
             _, _, reason_phrase = response.status.partition(" ")
             statuses[response.status_code] = reason_phrase

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -317,7 +317,7 @@ def _httpretty_callback(
     with test_client.open(environ_builder.get_request()) as response:
         statuses = cast(
             "dict[int, str]",
-            getattr(httpretty, "http").STATUSES,
+            httpretty.http.STATUSES,
         )
         if response.status_code not in statuses:
             _, _, reason_phrase = response.status.partition(" ")

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -4,7 +4,7 @@ import dataclasses
 import re
 from collections.abc import Callable
 from types import ModuleType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urljoin, urlsplit
 
 import httpretty
@@ -315,6 +315,14 @@ def _httpretty_callback(
         environ_overrides=environ_overrides,
     )
     with test_client.open(environ_builder.get_request()) as response:
+        statuses = cast(
+            "dict[int, str]",
+            getattr(httpretty, "http").STATUSES,
+        )
+        if response.status_code not in statuses:
+            _, _, reason_phrase = response.status.partition(" ")
+            statuses[response.status_code] = reason_phrase
+
         return (
             response.status_code,
             HTTPHeaderDict(headers=response.headers),

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -4,7 +4,7 @@ import dataclasses
 import re
 from collections.abc import Callable
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlsplit
 
 import httpretty
@@ -315,10 +315,7 @@ def _httpretty_callback(
         environ_overrides=environ_overrides,
     )
     with test_client.open(environ_builder.get_request()) as response:
-        statuses = cast(
-            "dict[int, str]",
-            httpretty.http.STATUSES,
-        )
+        statuses: dict[int, str] = getattr(httpretty, "http").STATUSES
         if response.status_code not in statuses:
             _, _, reason_phrase = response.status.partition(" ")
             statuses[response.status_code] = reason_phrase

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -242,7 +242,8 @@ def test_repeated_response_headers(mock_ctx: _MockCtxType) -> None:
 def nonstandard_httpretty_status() -> Iterator[int]:
     """Provide a status code and restore HTTPretty's global table."""
     status_code = 299
-    statuses: dict[int, str] = getattr(httpretty, "http").STATUSES
+    http_module: Any = vars(httpretty)["http"]
+    statuses: dict[int, str] = http_module.STATUSES
     assert status_code not in statuses
     yield status_code
     statuses.pop(status_code, None)

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -6,12 +6,12 @@ https://flask.palletsprojects.com/en/1.1.x/quickstart/#variable-rules
 
 import json
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager
 from functools import partial
 from http import HTTPStatus
 from types import ModuleType
-from typing import Any, Final
+from typing import Any, Final, cast
 
 import httpretty
 import httpx
@@ -236,6 +236,48 @@ def test_repeated_response_headers(mock_ctx: _MockCtxType) -> None:
 
     assert set_cookies == expected_set_cookie
     assert warnings == expected_warning
+
+
+@pytest.fixture
+def nonstandard_httpretty_status() -> Iterator[int]:
+    """Provide a status code and restore HTTPretty's global table."""
+    status_code = 299
+    statuses = cast(
+        "dict[int, str]",
+        getattr(httpretty, "http").STATUSES,
+    )
+    assert status_code not in statuses
+    yield status_code
+    statuses.pop(status_code, None)
+
+
+def test_httpretty_nonstandard_status_code(
+    nonstandard_httpretty_status: int,
+) -> None:
+    """HTTPretty forwards a nonstandard Flask status without crashing."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/")
+    def _() -> Response:
+        """Return a response with a nonstandard status."""
+        return Response(
+            response="x",
+            status=f"{nonstandard_httpretty_status} Custom Reason",
+        )
+
+    with httpretty.httprettized():
+        add_flask_app_to_mock(
+            mock_obj=httpretty,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+        response = _do_get(
+            mock_obj=httpretty,
+            url="http://www.example.com",
+        )
+
+    assert response.status_code == nonstandard_httpretty_status
+    assert response.text == "x"
 
 
 @_MOCK_CTX_MARKER

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -238,8 +238,8 @@ def test_repeated_response_headers(mock_ctx: _MockCtxType) -> None:
     assert warnings == expected_warning
 
 
-@pytest.fixture
-def nonstandard_httpretty_status() -> Iterator[int]:
+@pytest.fixture(name="nonstandard_httpretty_status")
+def fixture_nonstandard_httpretty_status() -> Iterator[int]:
     """Provide a status code and restore HTTPretty's global table."""
     status_code = 299
     http_module: Any = vars(httpretty)["http"]

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -244,7 +244,7 @@ def nonstandard_httpretty_status() -> Iterator[int]:
     status_code = 299
     statuses = cast(
         "dict[int, str]",
-        getattr(httpretty, "http").STATUSES,
+        httpretty.http.STATUSES,
     )
     assert status_code not in statuses
     yield status_code

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -11,7 +11,7 @@ from contextlib import AbstractContextManager
 from functools import partial
 from http import HTTPStatus
 from types import ModuleType
-from typing import Any, Final, cast
+from typing import Any, Final
 
 import httpretty
 import httpx
@@ -242,10 +242,7 @@ def test_repeated_response_headers(mock_ctx: _MockCtxType) -> None:
 def nonstandard_httpretty_status() -> Iterator[int]:
     """Provide a status code and restore HTTPretty's global table."""
     status_code = 299
-    statuses = cast(
-        "dict[int, str]",
-        httpretty.http.STATUSES,
-    )
+    statuses: dict[int, str] = getattr(httpretty, "http").STATUSES
     assert status_code not in statuses
     yield status_code
     statuses.pop(status_code, None)


### PR DESCRIPTION
Closes #1844.

HTTPretty builds the response status line with `STATUSES[status]` and raised `KeyError` in its callback thread for status codes absent from its fixed table (e.g. Flask's nonstandard `299`), surfacing to the caller as a connection-aborted error. The HTTPretty callback now registers any missing status code with the reason phrase from the Flask response, so the request returns the Flask status and body instead of crashing.

Adds a focused test that a Flask route returning `299 Custom Reason` is fetched via HTTPretty and yields status 299 with body `x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, HTTPretty-only change in the mock path; it mutates HTTPretty’s shared `STATUSES` dict but only for codes that were already missing, with test cleanup for the chosen code.
> 
> **Overview**
> Fixes **HTTPretty** integration when a Flask route returns a status code that is not in HTTPretty’s fixed `STATUSES` table (for example a custom `299 Custom Reason`). HTTPretty used to raise `KeyError` while building the status line, which showed up to callers as a broken connection.
> 
> In `_httpretty_callback`, before returning the Flask test-client response, the code now **adds any missing code** to `httpretty.http.STATUSES`, using the reason phrase from the Flask/Werkzeug status string.
> 
> A **HTTPretty-only test** exercises this path with a fixture that picks an unused code and removes it from the global table afterward so other tests are not affected. A news fragment documents the change for #1844.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 205c603fd575fe1d36dc030f3b1313309f805437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->