### PR TITLE
fix: Parse custom converter arguments without truncating at quoted greater-than signs

### DIFF
--- a/newsfragments/1851.change.rst
+++ b/newsfragments/1851.change.rst
@@ -1,1 +1,1 @@
-Custom converter arguments containing a quoted ``>`` are no longer truncated when generating URL patterns, so applications that use them can be attached to a mock backend.
+Custom converter arguments containing a quoted ``>`` are no longer truncated when generating URL patterns, so applications that use them can be attached to a mock back end.

--- a/newsfragments/1851.change.rst
+++ b/newsfragments/1851.change.rst
@@ -1,0 +1,1 @@
+Custom converter arguments containing a quoted ``>`` are no longer truncated when generating URL patterns, so applications that use them can be attached to a mock backend.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,6 +337,8 @@ ignore_names = [
     # pytest configuration
     "pytest_collect_file",
     "pytest_plugins",
+    # Werkzeug converter attribute, set on a custom converter in tests.
+    "regex",
     "rst_prolog",
     "source_suffix",
     "spelling_word_list_filename",

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -14,6 +14,7 @@ import requests_mock
 import responses
 import respx
 import werkzeug
+from werkzeug.routing.converters import PathConverter
 
 if TYPE_CHECKING:
     import flask
@@ -148,20 +149,36 @@ def add_flask_app_to_mock(
     )
 
     for rule in flask_app.url_map.iter_rules():
-        # We replace everything inside angle brackets with a regex pattern.
-        # For path variables (<path:...>), we use .+ to match any characters
-        # including slashes. For all other variable types, we use [^/]+ to
-        # match only within a single path segment.
-        path_to_match = re.sub(
-            pattern="<path:.+?>",
-            repl=".+",
-            string=rule.rule,
-        )
-        path_to_match = re.sub(
-            pattern="<.+?>",
-            repl="[^/]+",
-            string=path_to_match,
-        )
+        # Build the URL pattern from Werkzeug's parsed rule metadata rather
+        # than reparsing ``rule.rule`` with a naive regex. Reparsing breaks on
+        # converter arguments that contain a quoted ``>`` (e.g.
+        # ``<regex("[^>]+"):value>``). ``rule.compile()`` populates
+        # ``rule._trace`` with ``(is_dynamic, data)`` parts and
+        # ``rule._converters`` with each variable's converter.
+        #
+        # For path variables (``<path:...>``) we use ``.+`` to match any
+        # characters including slashes. For all other variable types we use
+        # ``[^/]+`` to match a single path segment. We deliberately do not use
+        # each converter's own (stricter) regex: requests with the "wrong" type
+        # should still be forwarded to the Flask app so that it can produce the
+        # appropriate response (e.g. a 404). Literal parts are kept literal.
+        rule.compile()
+        path_parts: list[str] = []
+        rule_trace = rule._trace  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        rule_converters = rule._converters  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        for is_dynamic, data in rule_trace:
+            if data == "|":
+                # Marker separating the (unused) host part from the path.
+                continue
+            if is_dynamic:
+                converter = rule_converters[data]
+                if isinstance(converter, PathConverter):
+                    path_parts.append(".+")
+                else:
+                    path_parts.append("[^/]+")
+            else:
+                path_parts.append(re.escape(pattern=data))
+        path_to_match = "".join(path_parts)
         pattern = urljoin(base=base_url, url=path_to_match)
         urls = (re.compile(pattern=pattern), re.compile(pattern=pattern + "$"))
 

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -166,9 +166,13 @@ def add_flask_app_to_mock(
         rule_attributes: Any = vars(rule)
         rule_trace = rule_attributes["_trace"]
         rule_converters = rule_attributes["_converters"]
+        seen_separator = False
         for is_dynamic, data in rule_trace:
-            if data == "|":
-                # Marker separating the (unused) host part from the path.
+            if not is_dynamic and data == "|":
+                # Marker separating the host part from the path.
+                seen_separator = True
+                continue
+            if not seen_separator:
                 continue
             if is_dynamic:
                 converter = rule_converters[data]

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -149,12 +149,11 @@ def add_flask_app_to_mock(
     )
 
     for rule in flask_app.url_map.iter_rules():
-        # Build the URL pattern from Werkzeug's parsed rule metadata rather
-        # than reparsing ``rule.rule`` with a naive regex. Reparsing breaks on
+        # Build the URL pattern from the framework's parsed rule metadata.
+        # Re-parsing ``rule.rule`` with a naive regex breaks on
         # converter arguments that contain a quoted ``>`` (e.g.
         # ``<regex("[^>]+"):value>``). ``rule.compile()`` populates
-        # ``rule._trace`` with ``(is_dynamic, data)`` parts and
-        # ``rule._converters`` with each variable's converter.
+        # internal parsed parts and each variable's converter.
         #
         # For path variables (``<path:...>``) we use ``.+`` to match any
         # characters including slashes. For all other variable types we use
@@ -164,8 +163,9 @@ def add_flask_app_to_mock(
         # appropriate response (e.g. a 404). Literal parts are kept literal.
         rule.compile()
         path_parts: list[str] = []
-        rule_trace = rule._trace  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
-        rule_converters = rule._converters  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        rule_attributes: Any = vars(rule)
+        rule_trace = rule_attributes["_trace"]
+        rule_converters = rule_attributes["_converters"]
         for is_dynamic, data in rule_trace:
             if data == "|":
                 # Marker separating the (unused) host part from the path.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -19,6 +19,7 @@ from werkzeug.routing.converters import PathConverter
 if TYPE_CHECKING:
     import flask
     import requests
+    from werkzeug.routing import Rule
 
 
 _MockObjType = (
@@ -161,28 +162,7 @@ def add_flask_app_to_mock(
         # each converter's own (stricter) regex: requests with the "wrong" type
         # should still be forwarded to the Flask app so that it can produce the
         # appropriate response (e.g. a 404). Literal parts are kept literal.
-        rule.compile()
-        path_parts: list[str] = []
-        rule_attributes: Any = vars(rule)
-        rule_trace = rule_attributes["_trace"]
-        rule_converters = rule_attributes["_converters"]
-        seen_separator = False
-        for is_dynamic, data in rule_trace:
-            if not is_dynamic and data == "|":
-                # Marker separating the host part from the path.
-                seen_separator = True
-                continue
-            if not seen_separator:
-                continue
-            if is_dynamic:
-                converter = rule_converters[data]
-                if isinstance(converter, PathConverter):
-                    path_parts.append(".+")
-                else:
-                    path_parts.append("[^/]+")
-            else:
-                path_parts.append(re.escape(pattern=data))
-        path_to_match = "".join(path_parts)
+        path_to_match = _rule_to_path_regex(rule=rule)
         pattern = urljoin(base=base_url, url=path_to_match)
         urls = (re.compile(pattern=pattern), re.compile(pattern=pattern + "$"))
 
@@ -195,6 +175,28 @@ def add_flask_app_to_mock(
                     url=url,
                     callbacks=callbacks,
                 )
+
+
+def _rule_to_path_regex(rule: "Rule") -> str:
+    """Return a regex that matches the path part of a Flask routing
+    rule.
+    """
+    rule.compile()
+    path_parts: list[str] = []
+    rule_attributes: Any = vars(rule)
+    rule_trace = rule_attributes["_trace"]
+    rule_converters = rule_attributes["_converters"]
+    separator_index = rule_trace.index((False, "|"))
+    for is_dynamic, data in rule_trace[separator_index + 1 :]:
+        if is_dynamic:
+            converter = rule_converters[data]
+            path_part = ".+"
+            if not isinstance(converter, PathConverter):
+                path_part = "[^/]+"
+            path_parts.append(path_part)
+        else:
+            path_parts.append(re.escape(pattern=data))
+    return "".join(path_parts)
 
 
 def _responses_callback(

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -24,6 +24,7 @@ import werkzeug
 from flask import Flask, Response, jsonify, make_response, request
 from requests_mock.exceptions import NoMockAddress
 from respx.models import AllMockedAssertionError
+from werkzeug.routing import BaseConverter, Map
 
 from requests_mock_flask import add_flask_app_to_mock
 
@@ -572,6 +573,68 @@ def test_route_with_multiple_variables(mock_ctx: _MockCtxType) -> None:
         mock_response = _do_get(
             mock_obj=mock_obj_to_add,
             url="http://www.example.com/users/cranes/frasier/posts",
+        )
+
+    assert mock_response.status_code == expected_status_code
+    assert mock_response.headers["Content-Type"] == expected_content_type
+    assert mock_response.text == expected_data.decode()
+
+
+@_MOCK_CTX_MARKER
+def test_route_with_custom_converter_quoted_gt(
+    mock_ctx: _MockCtxType,
+) -> None:
+    """A route with a custom converter argument containing a quoted ``>``
+    works.
+
+    The rule grammar allows a converter argument such as ``"[^>]+"`` to
+    contain a ``>``.  The pattern generation must not truncate the placeholder
+    at that quoted character.
+    """
+    app = Flask(import_name=__name__, static_folder=None)
+
+    class _RegexConverter(BaseConverter):
+        """A converter which matches a given regular expression."""
+
+        def __init__(
+            self,
+            url_map: Map,
+            pattern: str,
+        ) -> None:
+            """Store the given pattern as the converter's regex."""
+            super().__init__(map=url_map)
+            self.regex = pattern
+
+    app.url_map.converters["regex"] = _RegexConverter
+
+    @app.route(rule='/items/<regex("[^>]+"):my_variable>')
+    def _(my_variable: str) -> str:
+        """Return a simple message which includes the route variable."""
+        return "Hello: " + my_variable
+
+    test_client = app.test_client()
+    response = test_client.get("/items/abc")
+
+    expected_status_code = HTTPStatus.OK
+    expected_content_type = "text/html; charset=utf-8"
+    expected_data = b"Hello: abc"
+
+    assert response.status_code == expected_status_code
+    assert response.headers["Content-Type"] == expected_content_type
+    assert response.data == expected_data
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com",
+        )
+
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com/items/abc",
         )
 
     assert mock_response.status_code == expected_status_code


### PR DESCRIPTION
Closes #1851.

`add_flask_app_to_mock` previously reparsed `rule.rule` with a naive `<.+?>` regex to build the mock URL pattern. That truncated a placeholder at a quoted `>` inside a converter argument (e.g. `<regex("[^>]+"):value>`), leaving broken regex syntax and raising `re.PatternError` during registration.

The pattern is now built from Werkzeug's parsed rule metadata (`rule._trace` and `rule._converters`). Literal parts stay literal; path variables match across slashes (`.+`) and all other variables match a single segment (`[^/]+`), preserving the existing behaviour where wrong-type requests are still forwarded to the Flask app.

Adds a test using a custom `RegexConverter` with a quoted `>` in its argument, plus a news fragment. All existing route tests still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to URL pattern generation in test-mocking glue code; existing route tests cover prior behavior and a new test covers the regression.
> 
> **Overview**
> **Fixes mock registration for Flask routes whose custom converters use quoted `>` in their arguments** (e.g. `<regex("[^>]+"):value>`). The old approach re-parsed `rule.rule` with `<.+?>`, which cut off at the `>` inside the argument, produced invalid regex, and could raise `re.PatternError` when attaching the app to a mock.
> 
> `add_flask_app_to_mock` now builds path patterns via new helper `_rule_to_path_regex`, using Werkzeug’s compiled rule (`rule.compile()`, `_trace`, `_converters`): literals are escaped, `path` segments still use `.+`, and other variables use `[^/]+`, so behavior for wrong-type requests stays the same.
> 
> Adds a parametrized integration test with a custom `RegexConverter`, a towncrier note, and a Vulture ignore for the test converter’s `regex` attribute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c58ee021eb9f3c8f56719f550e9ec3a82b6bc51f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->