### PR TITLE
Use types-httpretty

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Usage examples
    from http import HTTPStatus
 
    import flask
-   import httpretty  # pyright: ignore[reportMissingTypeStubs]
+   import httpretty
    import httpx
    import requests
    import requests_mock
@@ -92,7 +92,7 @@ Usage examples
 
 
    # Using httpretty
-   with httpretty.core.httprettized():  # type: ignore[no-untyped-call]
+   with httpretty.core.httprettized():
        add_flask_app_to_mock(
            mock_obj=httpretty,
            flask_app=app,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ Usage examples
    from http import HTTPStatus
 
    import flask
-   import httpretty  # pyright: ignore[reportMissingTypeStubs]
+   import httpretty
    import httpx
    import requests
    import requests_mock
@@ -87,7 +87,7 @@ Usage examples
 
 
    # Using httpretty
-   with httpretty.core.httprettized():  # type: ignore[no-untyped-call]
+   with httpretty.core.httprettized():
        add_flask_app_to_mock(
            mock_obj=httpretty,
            flask_app=app,

--- a/newsfragments/types-httpretty.change.rst
+++ b/newsfragments/types-httpretty.change.rst
@@ -1,0 +1,1 @@
+Use ``types-httpretty`` to type-check the HTTPretty integration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ optional-dependencies.dev = [
     "sybil==10.1.0",
     "towncrier==25.8.0",
     "ty==0.0.60",
+    "types-httpretty==1.1.4.20260720.post1",
     "types-requests==2.33.0.20260712",
     "vulture==2.16",
     "yamlfix==1.19.1",

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -7,7 +7,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
-import httpretty  # pyright: ignore[reportMissingTypeStubs]
+import httpretty
 import httpx
 import requests_mock
 import responses
@@ -72,10 +72,10 @@ def _register_mock(
                 url__regex=url.pattern,
             ).mock(side_effect=callbacks.respx)
         case ModuleType() if mock_obj.__name__ == "httpretty":
-            httpretty.register_uri(  # type: ignore[no-untyped-call]  # pyright: ignore[reportUnknownMemberType]
+            httpretty.register_uri(
                 method=method,
                 uri=url,
-                body=callbacks.httpretty,  # pyright: ignore[reportArgumentType]
+                body=callbacks.httpretty,
                 forcing_headers={"Content-Type": None},
             )
         case _:

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -13,7 +13,7 @@ from http import HTTPStatus
 from types import ModuleType
 from typing import Any, Final
 
-import httpretty  # pyright: ignore[reportMissingTypeStubs]
+import httpretty
 import httpx
 import pytest
 import requests

--- a/tests/test_usage_patterns.py
+++ b/tests/test_usage_patterns.py
@@ -3,7 +3,7 @@
 from http import HTTPStatus
 from typing import Final
 
-import httpretty  # pyright: ignore[reportMissingTypeStubs]
+import httpretty
 import httpx
 import requests
 import requests_mock as req_mock
@@ -183,7 +183,7 @@ class TestHTTPretty:
             """Return a simple message."""
             return "Hello, World!"
 
-        with httpretty.enabled():  # type: ignore[no-untyped-call]
+        with httpretty.enabled():
             add_flask_app_to_mock(
                 mock_obj=httpretty,
                 flask_app=app,


### PR DESCRIPTION
## Summary

- add `types-httpretty` to the development dependencies
- remove HTTPretty missing-stub and untyped-call suppressions
- type-check the existing HTTPretty registration and context-manager usage

## Why

HTTPretty does not ship inline typing information. The new stub-only package
lets mypy and pyright validate this integration instead of treating it as
untyped.

## Validation

- 127 pytest tests
- strict mypy
- strict pyright
- Ruff check and format
- full commit and push hook suites

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only stub package and comment removals; HTTPretty behavior is unchanged.
> 
> **Overview**
> Adds **`types-httpretty`** to dev dependencies so mypy and pyright can type-check HTTPretty usage without treating it as untyped.
> 
> Removes **`# pyright: ignore`** and **`# type: ignore`** on `import httpretty`, `httpretty.register_uri`, and HTTPretty context managers in the library, tests, and documentation examples. A towncrier fragment records the change for the changelog.
> 
> **No runtime or API changes**—only stricter static typing for the existing HTTPretty integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d5ec75acdf8d11aea10d7ae9ce2a0b8b48b75a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->