### PR TITLE
Preserve path prefixes supplied in base_url

### DIFF
--- a/newsfragments/1833.change.rst
+++ b/newsfragments/1833.change.rst
@@ -1,0 +1,1 @@
+Path prefixes supplied in ``base_url`` are now preserved when registering Flask routes.

--- a/src/requests_mock_flask/__init__.py
+++ b/src/requests_mock_flask/__init__.py
@@ -7,7 +7,7 @@ import re
 from operator import methodcaller
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, BinaryIO
-from urllib.parse import quote, urljoin, urlsplit, urlunsplit
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
 import httpretty
 import httpx
@@ -254,6 +254,20 @@ def add_flask_app_to_mock(
     """
     base_url = _normalize_base_url(base_url=base_url)
     base_url = _normalize_base_url_host_to_idna(base_url=base_url)
+    split_base_url = urlsplit(url=base_url)
+    base_url_path = quote(
+        string=split_base_url.path.rstrip("/"),
+        safe="/%",
+    )
+    registration_base_url = urlunsplit(
+        components=(
+            split_base_url.scheme,
+            split_base_url.netloc,
+            base_url_path,
+            "",
+            "",
+        )
+    )
 
     def respx_wsgi_app(
         environ: WSGIEnvironment,
@@ -262,8 +276,14 @@ def add_flask_app_to_mock(
         """Normalize HTTPX's Unicode path to the WSGI latin-1
         convention.
         """
-        path_info = environ["PATH_INFO"]
-        environ["PATH_INFO"] = path_info.encode().decode("latin-1")
+        mount_path = unquote(string=base_url_path)
+        path_info = environ["PATH_INFO"].removeprefix(mount_path) or "/"
+        environ["SCRIPT_NAME"] = mount_path.encode().decode(
+            encoding="latin-1",
+        )
+        environ["PATH_INFO"] = path_info.encode().decode(
+            encoding="latin-1",
+        )
         return flask_app.wsgi_app(
             environ=environ,
             start_response=start_response,
@@ -281,7 +301,11 @@ def add_flask_app_to_mock(
         request: requests.PreparedRequest,
     ) -> tuple[int, HTTPHeaderDict, bytes]:
         """Callback for responses."""
-        return _responses_callback(request=request, flask_app=flask_app)
+        return _responses_callback(
+            request=request,
+            flask_app=flask_app,
+            base_url_path=base_url_path,
+        )
 
     def requests_mock_callback(
         request: requests_mock.Request,
@@ -292,6 +316,7 @@ def add_flask_app_to_mock(
             request=request,
             context=context,
             flask_app=flask_app,
+            base_url_path=base_url_path,
         )
 
     def httpretty_callback(
@@ -305,6 +330,7 @@ def add_flask_app_to_mock(
             uri=uri,
             headers=headers,
             flask_app=flask_app,
+            base_url_path=base_url_path,
         )
 
     callbacks = _MockCallbacks(
@@ -334,8 +360,8 @@ def add_flask_app_to_mock(
         # should still be forwarded to the Flask app so that it can produce the
         # appropriate response (e.g. a 404). Literal parts are kept literal.
         path_to_match = _rule_to_path_regex(rule=rule)
-        escaped_base_url = re.escape(pattern=base_url)
-        patterns = [urljoin(base=escaped_base_url, url=path_to_match)]
+        escaped_base_url = re.escape(pattern=registration_base_url)
+        patterns = [escaped_base_url + path_to_match]
         has_slashless_redirect = (
             rule.strict_slashes
             and path_to_match.endswith("/")
@@ -344,9 +370,7 @@ def add_flask_app_to_mock(
         if path_to_match == "/":
             patterns.append(patterns[0].rstrip("/"))
         elif has_slashless_redirect:
-            patterns.append(
-                urljoin(base=escaped_base_url, url=path_to_match.rstrip("/"))
-            )
+            patterns.append(escaped_base_url + path_to_match.rstrip("/"))
         urls = tuple(
             re.compile(pattern=pattern + r"(\?.*)?$") for pattern in patterns
         )
@@ -385,6 +409,7 @@ def _rule_to_path_regex(rule: Rule) -> str:
 def _responses_callback(
     request: requests.PreparedRequest,
     flask_app: flask.Flask,
+    base_url_path: str,
 ) -> tuple[int, HTTPHeaderDict, bytes]:
     """Given a request to the flask app, send an equivalent request to an
     in
@@ -410,9 +435,11 @@ def _responses_callback(
         headers=dict(request.headers).items(),
     )
     split_url = urlsplit(url=str(object=request.url))
-    base_url = f"{split_url.scheme}://{split_url.netloc}/"
+    base_url = (
+        f"{split_url.scheme}://{split_url.netloc}{base_url_path.rstrip('/')}/"
+    )
     environ_builder = werkzeug.test.EnvironBuilder(
-        path=request.path_url,
+        path=request.path_url.removeprefix(base_url_path) or "/",
         base_url=base_url,
         method=str(object=request.method),
         data=_normalize_body(body=request.body),
@@ -433,6 +460,7 @@ def _httpretty_callback(
     uri: str,
     headers: dict[str, Any],
     flask_app: flask.Flask,
+    base_url_path: str,
 ) -> tuple[int, HTTPHeaderDict, bytes]:
     """Given a request to the Flask app, send an equivalent request to an
     in
@@ -461,9 +489,11 @@ def _httpretty_callback(
         environ_overrides["CONTENT_LENGTH"] = request.headers["Content-Length"]
 
     split_url = urlsplit(url=uri)
-    base_url = f"{split_url.scheme}://{split_url.netloc}/"
+    base_url = (
+        f"{split_url.scheme}://{split_url.netloc}{base_url_path.rstrip('/')}/"
+    )
     environ_builder = werkzeug.test.EnvironBuilder(
-        path=str(object=request.path),
+        path=str(object=request.path).removeprefix(base_url_path) or "/",
         base_url=base_url,
         method=request.method,
         headers=request.headers.items(),
@@ -488,6 +518,7 @@ def _requests_mock_callback(
     request: requests_mock.Request,
     context: requests_mock.Context,
     flask_app: flask.Flask,
+    base_url_path: str,
 ) -> bytes:
     """Given a request to the Flask app, send an equivalent request to an
     in
@@ -511,9 +542,11 @@ def _requests_mock_callback(
     if "Content-Length" in request.headers:
         environ_overrides["CONTENT_LENGTH"] = request.headers["Content-Length"]
     split_url = urlsplit(url=str(object=request.url))
-    base_url = f"{split_url.scheme}://{split_url.netloc}/"
+    base_url = (
+        f"{split_url.scheme}://{split_url.netloc}{base_url_path.rstrip('/')}/"
+    )
     environ_builder = werkzeug.test.EnvironBuilder(
-        path=request.path_url,
+        path=request.path_url.removeprefix(base_url_path) or "/",
         base_url=base_url,
         method=request.method,
         headers=_without_transfer_encoding(headers=request.headers.items()),

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -178,6 +178,75 @@ def test_simple_route(mock_ctx: _MockCtxType) -> None:
     assert mock_response.text == expected_data.decode()
 
 
+@_MOCK_CTX_MARKER
+@pytest.mark.parametrize(
+    argnames="base_url",
+    argvalues=[
+        "http://www.example.com/service",
+        "http://www.example.com/service/",
+    ],
+)
+def test_base_url_path_prefix(
+    mock_ctx: _MockCtxType,
+    base_url: str,
+) -> None:
+    """A path in ``base_url`` prefixes the externally registered route."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/ping")
+    def _() -> str:
+        """Return a simple message."""
+        return "pong"
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url=base_url,
+        )
+
+        mock_response = _do_get(
+            mock_obj=mock_obj_to_add,
+            url="http://www.example.com/service/ping",
+        )
+
+    assert mock_response.status_code == HTTPStatus.OK
+    assert mock_response.text == "pong"
+
+
+@_MOCK_CTX_MARKER_NO_HTTPRETTY
+def test_base_url_path_prefix_does_not_register_route_at_origin(
+    mock_ctx: _MockCtxType,
+) -> None:
+    """A prefixed route is not also registered at the URL origin."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @app.route(rule="/ping")
+    def _() -> str:
+        """Return a simple message."""
+        return "pong"  # pragma: no cover
+
+    with mock_ctx() as mock_obj:
+        mock_obj_to_add = _get_mock_obj(mock_obj=mock_obj)
+        add_flask_app_to_mock(
+            mock_obj=mock_obj_to_add,
+            flask_app=app,
+            base_url="http://www.example.com/service",
+        )
+
+        expected_exceptions: tuple[type[Exception], ...] = (
+            AllMockedAssertionError,
+            requests.exceptions.ConnectionError,
+            NoMockAddress,
+        )
+        with pytest.raises(expected_exception=expected_exceptions):
+            _do_get(
+                mock_obj=mock_obj_to_add,
+                url="http://www.example.com/ping",
+            )
+
+
 def _get_response_header_list(
     *,
     mock_obj: _MockObjType,


### PR DESCRIPTION
Preserve path components supplied in `base_url` when registering Flask routes, rather than allowing absolute Flask rules to discard them. Mount forwarded requests under that prefix across responses, requests-mock, HTTPretty, and RESPX so Flask receives the expected internal path. Add regression coverage for trailing-slash variants and ensure the unprefixed origin route remains unmatched, plus a changelog fragment. Closes #1833.

Validated with the full pytest suite, repository checks, and pre-push type checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes URL matching and request path translation for every mock backend; fixes expected mount behavior but may differ from the previous incorrect prefix handling.
> 
> **Overview**
> **`base_url` path components are now honored** when mounting a Flask app on HTTP mocks, so e.g. `base_url="http://host/service"` registers `/service/...` instead of only the origin.
> 
> Mock URL patterns are built from a normalized **`registration_base_url`** (scheme + host + quoted path) concatenated with each Flask rule regex, replacing **`urljoin`**-based assembly that could drop the prefix. For **responses**, **requests-mock**, and **HTTPretty**, forwarded requests strip the mount path from the request path and include it in the Werkzeug **`base_url`**. **RESPX** sets **`SCRIPT_NAME`** / **`PATH_INFO`** on the WSGI environ the same way.
> 
> Regression tests cover trailing-slash variants on the prefix and confirm **`/ping`** at the origin stays unmatched when the app is mounted under **`/service`**. Changelog fragment added for #1833.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8688be853de1d96204dd6b39336d811bf7e98542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->