### PR TITLE
Run shfmt through uv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,7 +137,7 @@ repos:
 
       - id: shfmt
         name: shfmt
-        entry: shfmt --write --space-redirects --indent=4
+        entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
         additional_dependencies:


### PR DESCRIPTION
## What changed

- Run the `shfmt` pre-commit hook through `uv run --extra=dev`.

## Why

The project already pins `shfmt-py` in its development dependencies. Invoking `shfmt` directly made this hook inconsistent with the other project-tool hooks and allowed an ambient executable to be used instead of the pinned development environment.

## Impact

The hook now uses the project-pinned `shfmt` version. Formatting behavior and arguments are unchanged.

## Validation

- `uv run --extra=dev shfmt --version`
- `uv run --extra=dev prek run shfmt --all-files`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pre-commit tooling only; no application or security logic changes, with the same shfmt flags as before.
> 
> **Overview**
> The **`shfmt`** pre-commit hook now runs through **`uv run --extra=dev`**, matching hooks like **`shellcheck`** and **`actionlint`** instead of calling a **`shfmt`** binary from the PATH.
> 
> **`shfmt`** arguments are unchanged; only the invocation path changes so formatting uses the project-pinned **`shfmt-py`** dev dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ede47f986b3ba2e822bb9ecd37de0caf51029e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->