### PR TITLE
Add no-defaults linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -412,7 +412,7 @@ repos:
         stages: [pre-commit]
 
   - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: no-defaults
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -314,6 +314,16 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
+      - id: no-defaults
+        name: no-defaults
+        entry: uv run --extra=dev no-defaults
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
+
       - id: doc8
         name: doc8
         entry: uv run --extra=dev -m doc8
@@ -409,10 +419,4 @@ repos:
         types_or: [rst]
         additional_dependencies:
           - *uv_version
-        stages: [pre-commit]
-
-  - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.1
-    hooks:
-      - id: no-defaults
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -410,3 +410,9 @@ repos:
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
+
+  - repo: https://github.com/adamtheturtle/no-defaults
+    rev: v1.0.0
+    hooks:
+      - id: no-defaults
+        stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ lint.per-file-ignores."tests/test_*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.external = [ "NOD" ]
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.mccabe.max-complexity = 12
 lint.pydocstyle.convention = "google"
@@ -438,3 +439,7 @@ ignore_path = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[tool.no_defaults]
+private_only = true
+per_file_enforcement."tests/**" = "all"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
+    "no-defaults==1.0.1",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",
     "pylint[spelling]==4.0.6",

--- a/tests/test_requests_mock_flask.py
+++ b/tests/test_requests_mock_flask.py
@@ -103,8 +103,8 @@ def _do_get(
     *,
     mock_obj: _MockObjType,
     url: str,
-    headers: dict[str, str] | None = None,
-    allow_redirects: bool = True,
+    headers: dict[str, str] | None = None,  # noqa: NOD001
+    allow_redirects: bool = True,  # noqa: NOD001
 ) -> requests.Response | httpx.Response:
     """Make a GET request via the appropriate HTTP client."""
     if isinstance(mock_obj, (respx.MockRouter, respx.Router)):
@@ -126,7 +126,7 @@ def _do_post(
     *,
     mock_obj: _MockObjType,
     url: str,
-    cookies: dict[str, str] | None = None,
+    cookies: dict[str, str] | None = None,  # noqa: NOD001
 ) -> requests.Response | httpx.Response:
     """Make a POST request via the appropriate HTTP client."""
     if isinstance(mock_obj, (respx.MockRouter, respx.Router)):


### PR DESCRIPTION
Add `no-defaults` v1.0.0 to the pre-commit/prek configuration.

The policy rejects defaults everywhere in `tests/**` and for private functions, classes, and modules elsewhere. Existing defaults are behavior-preservingly baselined with targeted `# noqa: NOD001` comments where necessary; Ruff is configured to recognize the external `NOD` rule family. Vendored Typeshed is excluded where applicable.

Validated with `prek validate-config`, `prek run no-defaults --all-files`, and Ruff checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and style-policy only; runtime library behavior is unchanged aside from noqa comments on private test helpers.
> 
> **Overview**
> Adds **`no-defaults` v1.0.1** as a dev dependency and a **pre-commit** hook (`uv run --extra=dev no-defaults`) alongside the existing strict-kwargs check.
> 
> **Policy** is configured in `pyproject.toml`: **`private_only = true`** for library code (private functions/classes/modules) and **`per_file_enforcement."tests/**" = "all"`** so tests disallow parameter defaults everywhere. Ruff is wired to the external **`NOD`** rule family via `lint.external = ["NOD"]`.
> 
> Existing defaults in test helpers **`_do_get`** and **`_do_post`** are baselined with **`# noqa: NOD001`** so behavior stays the same while the new checks pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1afd1818c35d005dfdde55ec49301fe31ada202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->