### PR TITLE
Lint Markdown prose with Vale

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -325,7 +325,7 @@ repos:
         require_serial: true
 
       # Vale enforces prose style rules, such as banning em dashes, in
-      # reStructuredText files.
+      # reStructuredText and Markdown files.
       # The rules come from the ``ClearProse`` package pinned in ``.vale.ini``,
       # which ``vale sync`` downloads into the (gitignored) ``styles``
       # directory.
@@ -339,7 +339,7 @@ repos:
         entry: uv run --extra=dev vale sync
         language: python
         pass_filenames: false
-        files: (\.rst$|^\.vale\.ini$)
+        files: (\.(rst|md)$|^\.vale\.ini$)
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
@@ -348,7 +348,7 @@ repos:
         name: vale
         entry: uv run --extra=dev vale
         language: python
-        types_or: [rst]
+        types_or: [rst, markdown]
         require_serial: true
         additional_dependencies:
           - *uv_version

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,5 +3,5 @@ MinAlertLevel = error
 
 Packages = https://github.com/adamtheturtle/vale-style-clear-prose/releases/download/v1.1.0/ClearProse.zip
 
-[*.rst]
+[*.{rst,md}]
 BasedOnStyles = ClearProse


### PR DESCRIPTION
Follow-up to the change that banned em dashes in reStructuredText.

`.rst` was the wrong boundary: it came from the shape of the original vws-python change, not from where our prose lives. Markdown is prose too, and nothing was checking it. Vale now lints both (`[*.{rst,md}]`), and the `vale` hook gains `markdown` to its `types_or` while `vale sync` re-runs for `.md` changes as well.

No prose changes were needed here; the existing Markdown is already clean. The value is preventive, and it makes the rule consistent across every repository that has this hook.

Verified locally: Vale reports no alerts over the tracked `.rst` and `.md` files, and `prek run` over the changed files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to pre-commit and Vale file globs; no runtime, auth, or application logic is affected.
> 
> **Overview**
> **Vale** now applies the same **ClearProse** rules to **Markdown** as to reStructuredText, so prose style (e.g. em-dash bans) is enforced consistently across both formats.
> 
> In **`.vale.ini`**, the scope changes from `[*.rst]` to `[*.{rst,md}]`. In **`.pre-commit-config.yaml`**, the **`vale`** hook adds `markdown` to `types_or`, **`vale-sync`** also runs when `.md` files change, and the hook comment reflects both file types. No documentation prose was edited in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2774cf06b97289e38154e879ebb24e1e60455f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->