### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
-    "beartype==0.22.9",
+    "beartype==0.23.0rc0",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes a dev optional dependency pin; runtime package dependencies are untouched.
> 
> **Overview**
> Pins the **dev** optional dependency **`beartype`** from `0.22.9` to **`0.23.0rc0`** so CI and local dev installs exercise the release candidate against this repo’s test suite (including **`pytest-beartype-tests`**).
> 
> This is a **temporary evaluation pin**; the PR description notes it is not meant to merge as-is and the constraint should be relaxed after the RC is validated (e.g. back to a stable version).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30bb3231a39b6f0c31dd8ef9e5463a81d7e4f271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->