### PR TITLE
Bump mypy-strict-kwargs to 2026.8.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ optional-dependencies.dev = [
     "httpx==0.28.1",
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.1",
-    "mypy-strict-kwargs==2026.8.25",
+    "mypy-strict-kwargs==2026.8.25.1",
     "no-defaults==2.1.0",
     "prek==0.4.14",
     "pydocstringformatter==1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ optional-dependencies.dev = [
     "httpx==0.28.1",
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.1",
-    "mypy-strict-kwargs==2026.8.20.1",
+    "mypy-strict-kwargs==2026.8.25",
     "no-defaults==2.1.0",
     "prek==0.4.14",
     "pydocstringformatter==1.0.0",


### PR DESCRIPTION
`mypy-strict-kwargs` 2026.08.20.1 shipped two regressions, fixed in
2026.8.25 by https://github.com/adamtheturtle/mypy-strict-kwargs/pull/796:

- Its `get_attribute_hook` claimed every attribute name and so shadowed
  mypy's own default-plugin hooks, which is what gives `SomeEnum.value`
  its real type; every enum `.value` access degraded to `Any`.
- The new overloaded-call `call-arg` check reported decorator
  applications such as `@beartype`, which have no keyword form.

This bumps the pin and drops the `ignore_names` opt-outs that were added
for the second regression. Verified locally: mypy is clean without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CACFJDTrtojHAEbXRGoxAg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only mypy plugin version bump with no runtime or application code changes.
> 
> **Overview**
> Updates the dev dependency pin for **`mypy-strict-kwargs`** from `2026.8.20.1` to **`2026.8.25.1`** in `pyproject.toml`.
> 
> That release addresses regressions in the mypy plugin (broken enum `.value` typing and false positives on decorator applications such as `@beartype`), so type-checking can rely on the fixed plugin behavior again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a95e24883470b651e60e32637bd4ef8a3f67fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->